### PR TITLE
Fix rendering of appenders manual page

### DIFF
--- a/src/site/pages/manual/appenders.html
+++ b/src/site/pages/manual/appenders.html
@@ -4930,7 +4930,6 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 
     <p class="example">Example: SiftingAppender configuration (logback-examples/&#8203;src/main/resources/&#8203;chapters/appenders/&#8203;conf/sift/access-siftingFile.&#8203;xml)</p>
 
-        <!--
     <pre><code>&lt;configuration>
   &lt;appender name="SIFTING" class="ch.qos.logback.access.sift.SiftingAppender">
     &lt;Discriminator class="ch.qos.logback.access.sift.AccessEventDiscriminator">


### PR DESCRIPTION
The last section of the Appenders manual page got commented out, this commit removes that comment so it can be rendered properly.