### PR TITLE
Fix broken link to Javadoc for CountingFilter

### DIFF
--- a/src/site/pages/manual/filters.html
+++ b/src/site/pages/manual/filters.html
@@ -1071,7 +1071,7 @@ logger.debug("Hello {}.", name1);</code></pre>
 		name="countingFilter"><code>CountingFilter</code></h2>
 		
 		<p>With the help of <a
-		href="xref/ch/qos/logback/access/filter/CountingFilter.html"><code>CountingFilter</code></a>
+		href="../xref/ch/qos/logback/access/filter/CountingFilter.html"><code>CountingFilter</code></a>
 		class, logback-access can provide statistical data about access to
 		the web-server. Upon initialization, <code>CountingFilter</code>
 		registers itself as an MBean onto the platform's JMX server. You


### PR DESCRIPTION
This PR fixes a broken link to the Javadoc for the `CountingFilter`.