### PR TITLE
Fix log file location in Automatic file compression

### DIFF
--- a/src/site/pages/manual/appenders.html
+++ b/src/site/pages/manual/appenders.html
@@ -1158,7 +1158,7 @@ public interface RollingPolicy extends LifeCycle {
          file will be compressed to become
          <em>/wombat/foo.2009-11-23.gz</em>.  For the 24th of November,
          logging output will be directed to
-         <em>/wombat/folder/foo.&#8203;2009-11-24</em> until it's rolled over
+         <em>/wombat/foo.2009-11-24</em> until it's rolled over
          at the beginning of the next day.
          </p>
          


### PR DESCRIPTION
This PR fixes a log file location in the "Automatic file compression" section.

See https://github.com/qos-ch/logback/pull/393