### PR TITLE
Use id instead of (deprecated) name attribute for anchors

### DIFF
--- a/src/site/pages/access.html
+++ b/src/site/pages/access.html
@@ -55,7 +55,7 @@
         level of a web-application.
     </p>
 
-    <h1 class="doAnchor" name="tomcat">Logback-access under Tomcat</h1>
+    <h1 class="doAnchor" id="tomcat">Logback-access under Tomcat</h1>
 
     <p>To use logback-access with Tomcat, after downloading the
         logback distribution, place the files
@@ -139,7 +139,7 @@
     <pre><code>&lt;Valve className="ch.qos.&#8203;logback.access.&#8203;tomcat.LogbackValve"
         quiet="true" filename="c:/my-logback-access.&#8203;xml"/></code></pre>
 
-    <h3 class="doAnchor" name="viewingStatusMessages">Viewing status messages</h3>
+    <h3 class="doAnchor" id="viewingStatusMessages">Viewing status messages</h3>
 
     <p>Logback-access ships with a servlet called
         <code>ViewStatusMessagesServlet</code>. This servlet prints the
@@ -170,7 +170,7 @@
     </p>
 
 
-    <h1 class="doAnchor" name="jetty">Logback-access under Jetty</h1>
+    <h1 class="doAnchor" id="jetty">Logback-access under Jetty</h1>
 
     <p>After downloading the logback distribution, place the files
         <em>logback-core-VERSION.jar</em> and
@@ -276,7 +276,7 @@
   &lt;/Set&gt;
 &lt;/Ref&gt;</code></pre>
 
-    <h1 clas="doAnchor" name="configuration">Logback-access configuration</h1>
+    <h1 clas="doAnchor" id="configuration">Logback-access configuration</h1>
 
 
     <p>Although similar, the format of <em>logback-access.xml</em>
@@ -416,7 +416,7 @@
     </p>
 
 
-    <h2 class="doAnchor" name="teeFilter"><code>TeeFilter</code> <span class="small">(a servlet-filter)</span></h2>
+    <h2 class="doAnchor" id="teeFilter"><code>TeeFilter</code> <span class="small">(a servlet-filter)</span></h2>
 
     <p>In order to diagnose bugs in a web-application, it is often
         handy to capture the client's request as well as the server's

--- a/src/site/pages/codes.html
+++ b/src/site/pages/codes.html
@@ -16,9 +16,9 @@
 
   <div id="content">
     
-  <h2 class="doAnchor" name="top">Logback error messages and their meanings</h2>
+  <h2 class="doAnchor" id="top">Logback error messages and their meanings</h2>
 
-  <h3 class="doAnchor" name="null_CS">The contextSelector cannot be
+  <h3 class="doAnchor" id="null_CS">The contextSelector cannot be
   null in <code>StaticLoggerBinder</code>.  
   </h3>
 
@@ -35,7 +35,7 @@
   
 
   <!-- ================&#8203;===============&#8203;===============&#8203;============= -->
-  <h3 class="doAnchor" name="layoutInsteadOfEncoder">This appender no
+  <h3 class="doAnchor" id="layoutInsteadOfEncoder">This appender no
   longer admits a layout as a subcomponent, set an encoder instead.
   </h3>
 
@@ -135,7 +135,7 @@
 
   <!-- ================&#8203;===============&#8203;===============&#8203;============= -->
 
-  <h3 class="doAnchor" name="socket_no_host">No remote host or address
+  <h3 class="doAnchor" id="socket_no_host">No remote host or address
   is set for <code>SocketAppender</code>
     
   </h3>
@@ -157,7 +157,7 @@
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
 
-  <h3 class="doAnchor" name="socket_no_port">No remote port is set for
+  <h3 class="doAnchor" id="socket_no_port">No remote port is set for
   <code>SocketAppender</code>    
   </h3>
     
@@ -179,7 +179,7 @@
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
 
-  <h3 class="doAnchor" name="smtp_no_layout">No <code>Layout</code> is
+  <h3 class="doAnchor" id="smtp_no_layout">No <code>Layout</code> is
   set for SMTPAppender
   </h3>
 
@@ -211,7 +211,7 @@
       
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
 
-  <h3 class="doAnchor" name="sbtp_size_format">Specified number is not
+  <h3 class="doAnchor" id="sbtp_size_format">Specified number is not
   in proper int form, or not expected format.    
   </h3>
     
@@ -232,7 +232,7 @@
       
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
 
-  <h3 class="doAnchor" name="rfa_no_tp">No
+  <h3 class="doAnchor" id="rfa_no_tp">No
   <code>TriggeringPolicy</code> was set for the
   <code>RollingFileAppender</code>.
     
@@ -267,7 +267,7 @@
       
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
 
-  <h3 class="doAnchor" name="#sat_missing_integer_token">Missing
+  <h3 class="doAnchor" id="sat_missing_integer_token">Missing
   integer token, that is %i, in FileNamePattern [...].
     
   </h3>
@@ -283,7 +283,7 @@
       
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
 
-  <h3 class="doAnchor" name="rfa_no_rp">No <code>RollingPolicy</code>
+  <h3 class="doAnchor" id="rfa_no_rp">No <code>RollingPolicy</code>
   was set for the <code>RollingFileAppender</code>.    
   </h3>
   
@@ -318,7 +318,7 @@
   
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="tbr_fnp_not_set">The <span
+  <h3 class="doAnchor" id="tbr_fnp_not_set">The <span
   class="option">FileNamePattern</span> property is mandatory for both
   <code>TimeBasedRollingPolicy</code> and
   <code>FixedWindowRollingPolicy</code>.    
@@ -341,7 +341,7 @@
   
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="rfa_file_after">The <span
+  <h3 class="doAnchor" id="rfa_file_after">The <span
   class="option">File</span> property must be set before any rolling
   policy or triggering policy.
     
@@ -356,7 +356,7 @@
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->  
 
-  <h3 class="doAnchor" name="rfa_collision"><span
+  <h3 class="doAnchor" id="rfa_collision"><span
   class="option">File</span> property collides with <span
   class="option">fileNamePattern</span>. Aborting.
   </h3>
@@ -378,7 +378,7 @@
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->  
 
-  <h3 class="doAnchor" name="rfa_collision_in_dateFormat">The date
+  <h3 class="doAnchor" id="rfa_collision_in_dateFormat">The date
   format in <span class="option">fileNamePattern</span> will result in
   collisions in the names of archived log files.
   </h3>
@@ -399,7 +399,7 @@
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->  
 
-  <h3 class="doAnchor" name="earlier_fa_collision"><span
+  <h3 class="doAnchor" id="earlier_fa_collision"><span
   class="option">File</span>/<span
   class="option">FileNamePattern</span> option has the same value "..." as
   that given for appender [...] defined earlier.
@@ -422,7 +422,7 @@
   
   <!-- ================&#8203;===============&#8203;===============&#8203;===============
        -->
-  <h3 class="doAnchor" name="renamingError">Failed to rename file [x]
+  <h3 class="doAnchor" id="renamingError">Failed to rename file [x]
   as [y].</h3>
 
   <b>On Windows</b>
@@ -480,7 +480,7 @@
    class="option">file</span> property is mandatory.
    </p>
  
-   <h4 class="doAnchor" name="renamingErrorOnUnix">On Unix-*</h4>
+   <h4 class="doAnchor" id="renamingErrorOnUnix">On Unix-*</h4>
   
    <p>On the Unix platform, the basic/quick rename method supplied by
    the JDK does not work if the source and target files are located on
@@ -506,7 +506,7 @@
    </p>
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="fwrp_parentFileName_not_set">The <span
+  <h3 class="doAnchor" id="fwrp_parentFileName_not_set">The <span
   class="option">File</span> property must be set before
   <code>FixedWindowRollingPolicy</code>    
   </h3>
@@ -523,7 +523,7 @@
   </p>
 			
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="nested_if_element">Nested &lt;if&gt;
+  <h3 class="doAnchor" id="nested_if_element">Nested &lt;if&gt;
   element within &lt;appender&gt;, &lt;logger&gt; or &lt;root&gt;
   elements is disallowed
   </h3>
@@ -570,7 +570,7 @@
 
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="tbr_fnp_prudent_unsupported">Prudent mode
+  <h3 class="doAnchor" id="tbr_fnp_prudent_unsupported">Prudent mode
   is not supported with <code>FixedWindowRollingPolicy</code>.
   </h3>
 
@@ -584,7 +584,7 @@
   
   
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="syslog_layout">SyslogAppender does not
+  <h3 class="doAnchor" id="syslog_layout">SyslogAppender does not
   admit a layout.
   </h3>
 
@@ -603,7 +603,7 @@
   
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="1andOnly1">Only and only one appender can
+  <h3 class="doAnchor" id="1andOnly1">Only and only one appender can
   be nested the &lt;sift> element in
   <code>SiftingAppender</code>.</h3>
   
@@ -612,7 +612,7 @@
   
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="ifJanino">Could not find Janino library
+  <h3 class="doAnchor" id="ifJanino">Could not find Janino library
   on the class path. Skipping conditional processing.
   </h3>
   
@@ -624,7 +624,7 @@
   </p>
 
   <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-  <h3 class="doAnchor" name="block">As of logback version 0.9.28,
+  <h3 class="doAnchor" id="block">As of logback version 0.9.28,
   JaninoEventEvaluator expects Java blocks.
   </h3>
 
@@ -673,7 +673,7 @@ return false;</code></pre>
    </p>
 
      <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-   <h3 class="doAnchor" name="param">The &lt;param&gt; element is
+   <h3 class="doAnchor" id="param">The &lt;param&gt; element is
    deprecated in favor of a more direct syntax.
    </h3>
 
@@ -699,7 +699,7 @@ return false;</code></pre>
    </code></pre>
 
    <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-   <h3 class="doAnchor" name="missingRightParenthesis">In a conversion
+   <h3 class="doAnchor" id="missingRightParenthesis">In a conversion
    pattern, opened parenthesis must be closed.
    </h3>
    
@@ -712,7 +712,7 @@ return false;</code></pre>
    </p>
   
    <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-   <h3 class="doAnchor" name="saxParserConfiguration">Error during SAX parser configuration</h3>
+   <h3 class="doAnchor" id="saxParserConfiguration">Error during SAX parser configuration</h3>
 
    
    <p>If you see the following error is thrown during logback configuration
@@ -732,7 +732,7 @@ return false;</code></pre>
    <p>See also <a href="https://jira.qos.ch/browse/LOGBACK-1577">LOGBACK-1577</a>.</p>
    
    <!-- ================&#8203;===============&#8203;===============&#8203;=============== -->
-   <h3 class="doAnchor" name="appender_order">Appenders must be
+   <h3 class="doAnchor" id="appender_order">Appenders must be
    defined before they are referenced.
    </h3>
 

--- a/src/site/pages/faq.html
+++ b/src/site/pages/faq.html
@@ -24,7 +24,7 @@
 
       <script type="text/javascript" src="templates/sponsoredBy.js"></script>
 
-    <h2 class="doAnchor" name="top">Frequently Asked Questions</h2>
+    <h2 class="doAnchor" id="top">Frequently Asked Questions</h2>
       
     <h3>Logback project</h3>
 

--- a/src/site/pages/js/decorator.js
+++ b/src/site/pages/js/decorator.js
@@ -34,7 +34,7 @@ function decoratePropertiesInTables(anchor) {
 
    var tmpHTML = p.innerHTML;
    var propName = e.innerHTML;
-   var nameAttr = $(e).attr('name')
+   var nameAttr = $(e).attr('id')
     
    if(nameAttr == null) {
      var containerAttr = $(e).attr('container')
@@ -44,7 +44,7 @@ function decoratePropertiesInTables(anchor) {
        nameAttr = propName;
    }
    
-   p.innerHTML = "<a name='" + nameAttr + "' href='#" + nameAttr +
+   p.innerHTML = "<a href='#" + nameAttr +
                 "'><span class='anchor'/></a><b>" +tmpHTML +"</b>";
    scrollIfMatch(p, nameAttr, anchor);
  } // for 
@@ -55,10 +55,10 @@ function decorateConversionWordInTables(anchor) {
  for(var i = 0; i < elems.length; i++) {
    var e = elems[i];
    var tmpHTML = e.innerHTML;
-   var nameAttr = $(e).attr('name')
+   var nameAttr = $(e).attr('id')
    if(nameAttr == null) 
      continue;
-   e.innerHTML = "<a name='" + nameAttr + "' href='#" + nameAttr +
+   e.innerHTML = "<a href='#" + nameAttr +
                 "'><span class='anchor'/></a>" +tmpHTML;
    scrollIfMatch(e, nameAttr, anchor);
  }
@@ -70,11 +70,11 @@ function decorateDoAnchor(anchor) {
    for(var i = 0; i < elems.length; i++) {
      var e = elems[i];
      var tmpHTML = e.innerHTML;
-     var nameAttr = $(e).attr('name')
+     var nameAttr = $(e).attr('id')
      if(nameAttr == null) {
        nameAttr = camelCase($.trim(tmpHTML))
      }
-     e.innerHTML = "<a name='" + nameAttr + "' href='#" + nameAttr +
+     e.innerHTML = "<a href='#" + nameAttr +
                 "'><span class='anchor'/></a>" +tmpHTML;
      scrollIfMatch(e, nameAttr, anchor);
    }

--- a/src/site/pages/manual/appenders.html
+++ b/src/site/pages/manual/appenders.html
@@ -35,7 +35,7 @@
             <script src="../templates/setup.js"    type="text/javascript"></script>
 
 
-    <h2 class="doAnchor" name="whatIsAnAppender">What is an Appender?</h2>
+    <h2 class="doAnchor" id="whatIsAnAppender">What is an Appender?</h2>
     
     <p>Logback delegates the task of writing a logging event to
       components called appenders.  Appenders must implement
@@ -91,7 +91,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
 	</p>
 	
 	
-	<h2 class="doAnchor" name="AppenderBase">AppenderBase</h2>
+	<h2 class="doAnchor" id="AppenderBase">AppenderBase</h2>
 	
 	<p>The <a href="../xref/ch/qos/logback/core/AppenderBase.html">
 	<code>ch.qos.logback.core.&#8203;AppenderBase</code></a> class is an
@@ -228,7 +228,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
 
 	
 	<h2 class="doAnchor"
-	name="OutputStreamAppender">OutputStreamAppender
+	id="OutputStreamAppender">OutputStreamAppender
   </h2>
 	
 	<p><a
@@ -253,7 +253,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
     </tr>
     
     <tr>
-      <td><span class="prop" name="osaEncoder">encoder</span></td>
+      <td><span class="prop" id="osaEncoder">encoder</span></td>
 
       <td><a
       href="../xref/ch/qos/logback/core/encoder/Encoder.html"><code>Encoder</code></a></td>
@@ -264,7 +264,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
 			</td>
     </tr>
    <tr>
-     <td><span class="prop" name="immediateFlush">immediateFlush</span></td>
+     <td><span class="prop" id="immediateFlush">immediateFlush</span></td>
      <td><code>boolean</code></td>
      
      <td>The default value for <span
@@ -293,7 +293,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
 	<img src="images/chapters/appenders/appenderClassDiagram.jpg" alt="A UML diagram showing OutputStreamAppender and subclasses"/>
 	
 
-	<h2 class="doAnchor" name="ConsoleAppender">ConsoleAppender</h2>
+	<h2 class="doAnchor" id="ConsoleAppender">ConsoleAppender</h2>
 	
   <p>The <a href="../xref/ch/qos/logback/core/ConsoleAppender.html">
   <code>ConsoleAppender</code></a>, as the name indicates, appends on
@@ -406,7 +406,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
    href="../xref/chapters/appenders/ConfigurationTester.html">chapters.appenders.&#8203;ConfigurationTester</a> src/main/java/chapters/&#8203;appenders/conf/&#8203;logback-Console.xml</p>
 	
 	
-   <h2 class="doAnchor" name="FileAppender">FileAppender</h2>
+   <h2 class="doAnchor" id="FileAppender">FileAppender</h2>
 	
    <p>The <a
    href="../xref/ch/qos/logback/core/FileAppender.html"><code>FileAppender</code></a>,
@@ -587,7 +587,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
    src/main/java/chapters/&#8203;appenders/conf/&#8203;logback-fileAppender.&#8203;xml</p>
 	
 	
-   <h3 class="doAnchor" name="uniquelyNamed">Uniquely named files (by
+   <h3 class="doAnchor" id="uniquelyNamed">Uniquely named files (by
    timestamp)</h3>
    
    <p>During the application development phase or in the case of
@@ -677,7 +677,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
   ...
 &lt;/configuration></code></pre>
 
-   <h2 class="doAnchor" name="RollingFileAppender">RollingFileAppender
+   <h2 class="doAnchor" id="RollingFileAppender">RollingFileAppender
    </h2>
    
    <p><a
@@ -755,7 +755,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
        </td>
      </tr>	
      <tr>
-       <td valign="top"><span class="prop" name="prudentWithRolling">prudent</span></td>
+       <td valign="top"><span class="prop" id="prudentWithRolling">prudent</span></td>
 
        <td valign="top"><code>boolean</code></td>
 
@@ -788,7 +788,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
      </tr>
    </table>
 	
-   <h3 class="doAnchor" name="onRollingPolicies">Overview of rolling
+   <h3 class="doAnchor" id="onRollingPolicies">Overview of rolling
    policies</h3>
 	
    <p><a
@@ -825,7 +825,7 @@ public interface RollingPolicy extends LifeCycle {
         ================= -->
 
 	
-   <h4 class="doAnchor" name="TimeBasedRollingPolicy">TimeBasedRollingPolicy </h4>
+   <h4 class="doAnchor" id="TimeBasedRollingPolicy">TimeBasedRollingPolicy </h4>
 
    <p><a
    href="../xref/ch/qos/logback/core/rolling/TimeBasedRollingPolicy.html">
@@ -1319,7 +1319,7 @@ public interface RollingPolicy extends LifeCycle {
    </div>
   
 
-    <h3 class="doAnchor" name="SizeAndTimeBasedRollingPolicy">Size and
+    <h3 class="doAnchor" id="SizeAndTimeBasedRollingPolicy">Size and
     time based rolling policy</h3>
 
     
@@ -1407,7 +1407,7 @@ public interface RollingPolicy extends LifeCycle {
     <code>SizeAndTimeBasedRollingPolicy</code> is implemented with a
     <code>SizeAndTimeBasedFNATP</code> subcomponent.</p>
 
-   <h4 class="doAnchor" name="FixedWindowRollingPolicy">FixedWindowRollingPolicy</h4>
+   <h4 class="doAnchor" id="FixedWindowRollingPolicy">FixedWindowRollingPolicy</h4>
 
    <p>When rolling over, <a
    href="../xref/ch/qos/logback/core/rolling/FixedWindowRollingPolicy.html">
@@ -1598,7 +1598,7 @@ public interface RollingPolicy extends LifeCycle {
      </div>
 
 
-    <h2 class="doAnchor" name="TriggeringPolicy">Overview of triggering policies</h2>
+    <h2 class="doAnchor" id="TriggeringPolicy">Overview of triggering policies</h2>
 		
     <p><a
     href="../xref/ch/qos/logback/core/rolling/TriggeringPolicy.html"><code>TriggeringPolicy</code></a>
@@ -1703,8 +1703,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
 
 	
     <!-- XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXx -->
-    <a name="Classic"></a>
-    <h2>Logback Classic</h2>
+    <h2 id="Classic">Logback Classic</h2>
     
     
     <p>While logging events are generic in logback-core, within
@@ -1715,7 +1714,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
     
     </p>
     
-    <h3 class="doAnchor" name="SocketAppender">SocketAppender and
+    <h3 class="doAnchor" id="SocketAppender">SocketAppender and
     SSLSocketAppender
     </h3>
     
@@ -1910,7 +1909,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
       </li>
     </ul>
     
-    <h4><a name="simpleSocketServer"></a>Using SimpleSocketServer</h4>
+    <h4 id="simpleSocketServer">Using SimpleSocketServer</h4>
     <p>
     The <code>SimpleSocketServer</code> application takes two command-line
     arguments: <em>port</em> and <em>configFile</em>; 
@@ -2055,7 +2054,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
 		its clients to a second server.
 		</p>
 		
-		<h4><a name="simpleSSLSocketServer"></a>Using SimpleSSLSocketServer</h4>
+		<h4 id="simpleSSLSocketServer">Using SimpleSSLSocketServer</h4>
 
     <p>The <code>SimpleSSLSocketServer</code> requires the same
     <em>port</em> and <em>configFile</em> command-line arguments used
@@ -2175,7 +2174,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
     </p>
  	  
  	  
-    <h3 class="doAnchor" name="serverSocketAppender">
+    <h3 class="doAnchor" id="serverSocketAppender">
       ServerSocketAppender and SSLServerSocketAppender</h3>
     
     <p>The <code>SocketAppender</code> component (and its SSL-enabled
@@ -2399,7 +2398,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
       </tr>
       
       <tr>
-        <td><span class="prop" name="smtpTo">to</span></td>
+        <td><span class="prop" id="smtpTo">to</span></td>
         <td><code>String</code></td>
         <td>The email address of the recipient as a
         <em>pattern</em>. The pattern is evaluated anew with the
@@ -2470,7 +2469,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
         </td>
       </tr>
       <tr>
-        <td><span class="prop" name="smtpAppender_Evaluator">evaluator</span></td>
+        <td><span class="prop" id="smtpAppender_Evaluator">evaluator</span></td>
         <td><code><a
         href="../xref/ch/qos/logback/classic/boolex/IEvaluator.html">IEvaluator</a></code></td>
         <td>
@@ -2796,7 +2795,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
     <code>HTMLLayout</code> does not use inline CSS.
     </p>
 
-    <h3 class="doAnchor" name="cyclicBufferSize">Custom buffer
+    <h3 class="doAnchor" id="cyclicBufferSize">Custom buffer
     size</h3>
 
     <p>By default, the outgoing message will contain the last 256
@@ -2954,7 +2953,7 @@ public class CounterBasedEvaluator extends ContextAwareBase implements EventEval
     </div>
 
 
-    <h3 class="doAnchor" name="OnMarkerEvaluator">Marker based
+    <h3 class="doAnchor" id="OnMarkerEvaluator">Marker based
     triggering </h3>
 
     <p>Although reasonable, the default triggering policy whereby every
@@ -3027,7 +3026,7 @@ logger.error(<b>notifyAdmin</b>,
 
 
     <h4 class="doAnchor"
-    name="marker_JaninoEventEvaluator">Marker-based triggering with
+    id="marker_JaninoEventEvaluator">Marker-based triggering with
     JaninoEventEvaluator</h4>
 
     <p>Note that instead of using the marker-centric
@@ -3073,7 +3072,7 @@ logger.error(<b>notifyAdmin</b>,
    </div>
    
 
-    <h3 class="doAnchor" name="smtpAuthentication">Authentication/STARTTLS/SSL</h3>
+    <h3 class="doAnchor" id="smtpAuthentication">Authentication/STARTTLS/SSL</h3>
 
     <p><code>SMTPAppender</code> supports authentication via plain
     user passwords as well as both the STARTTLS and SSL
@@ -3084,7 +3083,7 @@ logger.error(<b>notifyAdmin</b>,
     connection is encrypted right from the start.
     </p>
 
-    <h3 class="doAnchor" name="gmailSSL">SMTPAppender configuration
+    <h3 class="doAnchor" id="gmailSSL">SMTPAppender configuration
     for Gmail (SSL)</h3>
 
     <p>The next example shows you how to configure
@@ -3130,7 +3129,7 @@ logger.error(<b>notifyAdmin</b>,
       <p>Requires a server call. Please wait a few seconds.</p>
     </div>
     
-    <h3 class="doAnchor" name="gmailSTARTTLS">SMTPAppender for Gmail
+    <h3 class="doAnchor" id="gmailSTARTTLS">SMTPAppender for Gmail
     (STARTTLS)</h3>
 
     <p>The next example shows you how to configure
@@ -3176,7 +3175,7 @@ logger.error(<b>notifyAdmin</b>,
       <p>Requires a server call. Please wait a few seconds.</p>
     </div>
 
-    <h3 class="doAnchor" name="smtpDiscriminator">SMTPAppender with MDCDiscriminator</h3>
+    <h3 class="doAnchor" id="smtpDiscriminator">SMTPAppender with MDCDiscriminator</h3>
 
 
     <p>As mentioned earlier, by specifying a discriminator other than
@@ -3284,7 +3283,7 @@ logger.error(<b>notifyAdmin</b>,
     <!-- ================&#8203;=========================================== -->
 
 
-    <h3 class="doAnchor" name="DBAppender">DBAppender</h3>
+    <h3 class="doAnchor" id="DBAppender">DBAppender</h3>
 		
 		<p>The <a
 		href="../xref/ch/qos/logback/classic/db/DBAppender.html"><code>DBAppender</code></a>
@@ -3783,7 +3782,7 @@ logger.error(<b>notifyAdmin</b>,
 		-->
 
     <h4 class="doAnchor"
-    name="JNDIConnectionSource">JNDIConnectionSource</h4>
+    id="JNDIConnectionSource">JNDIConnectionSource</h4>
 
 		<p><a
 		href="../xref/ch/qos/logback/core/db/JNDIConnectionSource.html">
@@ -3980,7 +3979,7 @@ logger.error(<b>notifyAdmin</b>,
      improvement in performance.
      </p>
 
-     <h3 class="doAnchor" name="SyslogAppender">SyslogAppender</h3>
+     <h3 class="doAnchor" id="SyslogAppender">SyslogAppender</h3>
 
      <p>The syslog protocol is a very simple protocol: a syslog sender
      sends a small message to a syslog receiver.  The receiver is
@@ -4119,7 +4118,7 @@ logger.error(<b>notifyAdmin</b>,
     </p>
 		
 
-    <h3 class="doAnchor" name="SiftingAppender">SiftingAppender</h3>
+    <h3 class="doAnchor" id="SiftingAppender">SiftingAppender</h3>
 
     <p>As its name implies, a <code>SiftingAppender</code> can be used
     to separate (or sift) logging according to a given runtime
@@ -4276,7 +4275,7 @@ logger.debug("Alice says hello"); </p>
     also supported.
     </p>
 
-    <h4 class="doAnchor" name="siftGettingTimeoutRight">Getting the
+    <h4 class="doAnchor" id="siftGettingTimeoutRight">Getting the
     <span class="prop">timeout</span> right</h4>
 
     <p>For certain types of applications, it may be difficult to get
@@ -4327,7 +4326,7 @@ import static ch.qos.logback.classic.&#8203;ClassicConstants.&#8203;FINALIZE_SES
 
 </code></pre>
 
-    <h3 class="doAnchor" name="AsyncAppender">AsyncAppender</h3>
+    <h3 class="doAnchor" id="AsyncAppender">AsyncAppender</h3>
 
     <p>AsyncAppender logs <a
     href="../apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html">ILoggingEvent</a>s
@@ -4519,7 +4518,7 @@ import static ch.qos.logback.classic.&#8203;ClassicConstants.&#8203;FINALIZE_SES
     </div>
 
 
-    <h3 class="doAnchor" name="WriteYourOwnAppender">Writing your own
+    <h3 class="doAnchor" id="WriteYourOwnAppender">Writing your own
     Appender</h3>
     
 
@@ -4638,7 +4637,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 		</p>
   
 
-		<h2 class="doAnchor" name="logback_access">Logback Access</h2>
+		<h2 class="doAnchor" id="logback_access">Logback Access</h2>
 		
 		<p>Most of the appenders found in logback-classic have their
 		equivalent in logback-access. These work essentially in the same
@@ -4646,7 +4645,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 		will cover their use.
 		</p>
 		
-		<h3 class="doAnchor" name="AccessSocketAppender">SocketAppender
+		<h3 class="doAnchor" id="AccessSocketAppender">SocketAppender
 		and SSLSocketAppender</h3>
 		
 		<p>The <a
@@ -4671,7 +4670,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 		</p>
 
     <h3 class="doAnchor"
-    name="AccessServerSocketAppender">ServerSocketAppender and
+    id="AccessServerSocketAppender">ServerSocketAppender and
     SSLServerSocketAppender</h3>
     
     <p>Like <code>SocketAppender</code>, the <a
@@ -4696,7 +4695,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
     </p>
     
 	 	
-		<h3 class="doAnchor" name="AccessSMTPAppender">SMTPAppender</h3>
+		<h3 class="doAnchor" id="AccessSMTPAppender">SMTPAppender</h3>
 		
 		<p>Access' <a
 		href="../xref/ch/qos/logback/access/net/SMTPAppender.html">
@@ -4739,7 +4738,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 		included in the email.
 		</p>
 
-		<h3 class="doAnchor" name="AccessDBAppender">DBAppender</h3>
+		<h3 class="doAnchor" id="AccessDBAppender">DBAppender</h3>
 		
 		<p><a
 		href="../xref/ch/qos/logback/access/db/DBAppender.html"><code>DBAppender</code></a>
@@ -4907,7 +4906,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 
 
     <h3 class="doAnchor"
-    name="AccessSiftingAppender">SiftingAppender</h3>
+    id="AccessSiftingAppender">SiftingAppender</h3>
    
     <p>The SiftingAppender in logback-access is quite similar to its
     logback-classic counterpart. The main difference is that in

--- a/src/site/pages/manual/architecture.html
+++ b/src/site/pages/manual/architecture.html
@@ -83,7 +83,7 @@
 		loggers.
 		</p>
     
-    <h3 class="doAnchor" name="LoggerContext">Logger context</h3>
+    <h3 class="doAnchor" id="LoggerContext">Logger context</h3>
 
 		<p>The first and foremost advantage of any logging API over plain
 		<code>System.out.println</code> resides in its ability to disable
@@ -149,7 +149,7 @@ public interface Logger {
 
 
 
-    <h3 class="doAnchor" name="effectiveLevel">Effective Level aka
+    <h3 class="doAnchor" id="effectiveLevel">Effective Level aka
     Level Inheritance </h3>
 
 		<p>Loggers may be assigned levels. The set of possible levels
@@ -329,7 +329,7 @@ public interface Logger {
 		parent <code>X</code>, which has an assigned level.
 		</p>
 
-    <h3 class="doAnchor" name="basic_selection">Printing methods and
+    <h3 class="doAnchor" id="basic_selection">Printing methods and
     the basic selection rule</h3>
 
 		<p>By definition, the printing method determines the level of a
@@ -466,8 +466,7 @@ barlogger.<span class="green bold">info</span>("Located nearest gas station.");
 // This request is disabled, because <span class="green bold">DEBUG</span> &lt; <span class="blue">INFO</span>. 
 barlogger.<span class="green bold">debug</span>("Exiting gas station search");</code></pre>
 
-    <a name="RetrievingLoggers"></a>
-		<h3>Retrieving Loggers</h3>
+		<h3 id="RetrievingLoggers">Retrieving Loggers</h3>
 		<p>
 			Calling the <code><a href="../apidocs/org/slf4j/LoggerFactory.html#getLogger(java.lang.String)">LoggerFactory.getLogger</a></code>
 			method with the same name will always return a reference to
@@ -511,8 +510,7 @@ Logger y = LoggerFactory.getLogger("wombat");</code></pre>
 		located seems to be the best general strategy known so far.
 		</p>
 
-    <a name="AppendersAndLayouts"></a>
-    <h3>Appenders and Layouts</h3>
+    <h3 id="AppendersAndLayouts">Appenders and Layouts</h3>
 
 		<p>The ability to selectively enable or disable logging requests
 		based on their logger is only part of the picture.  Logback allows
@@ -547,8 +545,7 @@ Logger y = LoggerFactory.getLogger("wombat");</code></pre>
 		</p>
 		<div class="definition">
 
-			<h4 class="deftitle"><a name="additivity"
-			href="#additivity"><span class="anchor"/></a>Appender
+			<h4 class="deftitle anchor" id="additivity">Appender
 			Additivity</h4>
 
 			<p>The output of a log statement of logger <em>L</em> will go to
@@ -660,7 +657,7 @@ Logger y = LoggerFactory.getLogger("wombat");</code></pre>
 		</p>
 
 
-		<h3 class="doAnchor" name="parametrized">Parameterized
+		<h3 class="doAnchor" id="parametrized">Parameterized
 		logging</h3>
 
 		<p>Given that loggers in logback-classic implement the <a
@@ -745,8 +742,7 @@ logger.debug("The new entry is {}.", entry);</code></pre>
                 <p>Note that the varags variant incurs the cost of the
                 creation of an Object[] instance.</p>
   
-  <a name="UnderTheHood"></a>
-  <h3>A peek under the hood</h3>
+  <h3 id="UnderTheHood">A peek under the hood</h3>
 
   <p>After we have introduced the essential logback components, we are
   now ready to describe the steps that the logback framework takes
@@ -841,7 +837,7 @@ logger.debug("The new entry is {}.", entry);</code></pre>
   </a>
 
   
-  <h3 class="doAnchor" name="performance">Performance</h3>
+  <h3 class="doAnchor" id="performance">Performance</h3>
 
   <p>One of the often-cited arguments against logging is its
   computational cost.  This is a legitimate concern as even

--- a/src/site/pages/manual/configuration.html
+++ b/src/site/pages/manual/configuration.html
@@ -45,7 +45,7 @@
     </p>
 
 
-    <h2 class="doAnchor" name="auto_configuration">Configuration in
+    <h2 class="doAnchor" id="auto_configuration">Configuration in
     logback</h2>
 
     <p>Inserting log requests into the application code requires a
@@ -168,7 +168,7 @@
     serving as a good starting point.</p>
 
  
-    <h3 class="doAnchor" name="automaticConf">Automatically
+    <h3 class="doAnchor" id="automaticConf">Automatically
     configuring logback</h3>
 
     <p>The simplest way to configure logback is by letting logback
@@ -318,7 +318,7 @@ public class Foo {
    application should give identical results to its previous run.</p>
 
 
-   <h4 class="doAnchor" name="automaticStatusPrinting">Automatic
+   <h4 class="doAnchor" id="automaticStatusPrinting">Automatic
    printing of status messages in case of warning or errors</h4>
 
    <p class="highlight">If warning or errors occur during the parsing
@@ -374,7 +374,7 @@ public static void main(String[] args) {
   which allow convenient access to logback's internal state.
   </p>
 
-   <h4 class="doAnchor" name="dumpingStatusData">Status data</h4>
+   <h4 class="doAnchor" id="dumpingStatusData">Status data</h4>
 
    <p class="highlight">Enabling output of status data usually goes a
    long way in the diagnosis of issues with logback.</p>
@@ -494,7 +494,7 @@ public static void main(String[] args) {
 
 
    <h3 class="doAnchor"
-   name="logback.statusLC">"logback.statusListenerClass" system
+   id="logback.statusLC">"logback.statusListenerClass" system
    property</h3>
 
    <p>One may also register a status listener by setting the
@@ -523,7 +523,7 @@ public static void main(String[] args) {
 
    <p class="source">java <b>-Dlogback.statusListenerClass</b>=ch.qos.logback.&#8203;core.status.NopStatusListener&nbsp;.&#8203;..</p>
 
-   <h3 class="doAnchor" name="viewingStatusMessages">Viewing status
+   <h3 class="doAnchor" id="viewingStatusMessages">Viewing status
    messages </h3>
 
    <p>Logback collects its internal status data in a <code><a
@@ -568,7 +568,7 @@ public static void main(String[] args) {
    </p>
 
 
-   <h3 class="doAnchor" name="statusListenerViaCode">Listening to status messages via code</h3>
+   <h3 class="doAnchor" id="statusListenerViaCode">Listening to status messages via code</h3>
 
    <p>You may also register a <code>StatusListener</code> via Java
    code. Here is <a
@@ -590,7 +590,7 @@ public static void main(String[] args) {
 
    <!-- ================&#8203;===============&#8203;===============&#8203;============= -->
 
-   <h2 class="doAnchor" name="configFileProperty">Setting the location
+   <h2 class="doAnchor" id="configFileProperty">Setting the location
    of the configuration file via a system property</h2>
 
    <p>You may specify the location of the default configuration file
@@ -623,7 +623,7 @@ public class ServerMain {
     }
 }</code></pre>
 
-   <h3 class="doAnchor" name="autoScan">Automatically reloading
+   <h3 class="doAnchor" id="autoScan">Automatically reloading
    configuration file upon modification</h3>
 
    <p class="highlight">Logback-classic can scan for changes in its
@@ -684,7 +684,7 @@ public class ServerMain {
    XML syntax errors.</p>
 
 
-   <h4 class="doAnchor" name="packagingData">Enabling packaging data in stack traces</h4>
+   <h4 class="doAnchor" id="packagingData">Enabling packaging data in stack traces</h4>
 
    <p class="highlight">While useful, packaging data is expensive to
    compute, especially in applications with frequent exceptions.</p>
@@ -732,7 +732,7 @@ java.lang.Exception: 99 is invalid
   <b>lc.setPackagingDataEnabled(true);</b>
 </code></pre>
 
-   <h3 class="doAnchor" name="joranDirectly">Invoking
+   <h3 class="doAnchor" id="joranDirectly">Invoking
    <code>JoranConfigurator</code> directly</h3>
 
    <p>Logback relies on a configuration library called Joran, part of
@@ -795,7 +795,7 @@ public class MyApp3 {
    <code>context.reset()</code> invocation should be omitted.</p>
 
 
-   <h2 class="doAnchor" name="stopContext">Stopping
+   <h2 class="doAnchor" id="stopContext">Stopping
    logback-classic</h2>
 
    <p>In order to release the resources used by logback-classic, it is
@@ -822,7 +822,7 @@ import ch.qos.logback.classic.LoggerContext;
    installed automatically for you (<a href="#webShutdownHook">see just below</a>).
    </p>
 
-   <h4 class="doAnchor" name="shutdownHook">Stopping logback-classic
+   <h4 class="doAnchor" id="shutdownHook">Stopping logback-classic
    via a shutdown hook</h4>
 
    <p>Installing a JVM shutdown hook is a convenient way for shutting
@@ -872,7 +872,7 @@ import ch.qos.logback.classic.LoggerContext;
 
 
 
-    <h4 class="doAnchor" name="webShutdownHook">WebShutdownHook or stopping logback-classic
+    <h4 class="doAnchor" id="webShutdownHook">WebShutdownHook or stopping logback-classic
    in web-applications</h4>
 
    <p><span class="label">since 1.1.10</span> Logback-classic will
@@ -912,7 +912,7 @@ import ch.qos.logback.classic.LoggerContext;
    <!-- =================================================================== -->
    <!-- =================================================================== -->
 
-   <h2 class="doAnchor" name="syntax">Configuration file syntax</h2>
+   <h2 class="doAnchor" id="syntax">Configuration file syntax</h2>
 
    <p>As you have seen thus far in the manual with plenty of examples
    still to follow, logback allows you to redefine logging behavior
@@ -950,7 +950,7 @@ import ch.qos.logback.classic.LoggerContext;
     href="http://en.wikipedia.org/wiki/CamelCase">camelCase
     convention</a> which is almost always the correct convention.</p>
 
-    <h4 class="doAnchor" name="caseSensitivity">Case sensitivity of
+    <h4 class="doAnchor" id="caseSensitivity">Case sensitivity of
     tag names</h4>
 
     <p>Since logback version 0.9.17, tag names pertaining to explicit
@@ -975,7 +975,7 @@ import ch.qos.logback.classic.LoggerContext;
     almost always the correct convention.
     </p>
 
-    <h4 class="doAnchor" name="loggerElement">Configuring loggers, or
+    <h4 class="doAnchor" id="loggerElement">Configuring loggers, or
     the <code>&lt;logger></code> element</h4>
 
 
@@ -1016,7 +1016,7 @@ import ch.qos.logback.classic.LoggerContext;
 
 
 
-   <h4 class="doAnchor" name="rootElement">Configuring the root
+   <h4 class="doAnchor" id="rootElement">Configuring the root
    logger, or the <code>&lt;root></code> element</h4>
 
    <p>The <code>&lt;root></code> element configures the root
@@ -1289,7 +1289,7 @@ import ch.qos.logback.classic.LoggerContext;
   - even if the Java source code does not directly refer to it.
   </p>
 
-  <h4 class="doAnchor" name="configuringAppenders">Configuring
+  <h4 class="doAnchor" id="configuringAppenders">Configuring
   Appenders</h4>
 
   <p>An appender is configured with the <code>&lt;appender></code>
@@ -1398,7 +1398,7 @@ import ch.qos.logback.classic.LoggerContext;
   means for sharing encoders or layouts.
   </p>
 
-  <h4 class="doAnchor" name="cumulative">Appenders accumulate
+  <h4 class="doAnchor" id="cumulative">Appenders accumulate
   </h4>
 
   <p>By default, <b>appenders are cumulative</b>: a logger will log to
@@ -1516,7 +1516,7 @@ import ch.qos.logback.classic.LoggerContext;
   children will go into the <em>myApp.log</em> file.
   </p>
 
-  <h4 class="doAnchor" name="overridingCumulativity">Overriding the
+  <h4 class="doAnchor" id="overridingCumulativity">Overriding the
   default cumulative behaviour</h4>
 
   <p>In case the default cumulative behavior turns out to be
@@ -1579,7 +1579,7 @@ import ch.qos.logback.classic.LoggerContext;
   <em>foo.log</em> file and only in that file.
   </p>
 
-  <h3 class="doAnchor" name="contextName">Setting the context
+  <h3 class="doAnchor" id="contextName">Setting the context
   name</h3>
 
   <p>As mentioned <a href="architecture.html#LoggerContext">in an
@@ -1629,7 +1629,7 @@ import ch.qos.logback.classic.LoggerContext;
 
   <!-- =============================================================== -->
 
-  <h3 class="doAnchor" name="variableSubstitution">Variable
+  <h3 class="doAnchor" id="variableSubstitution">Variable
   substitution</h3>
 
   <p><span class="label">Note</span> Earlier versions of this document
@@ -1667,7 +1667,7 @@ import ch.qos.logback.classic.LoggerContext;
   href="#definingProps">configuration directly.</a>
   </p>
 
-   <h4 class="doAnchor" name="definingProps">Defining variables</h4>
+   <h4 class="doAnchor" id="definingProps">Defining variables</h4>
 
   <p>Variables can be defined one at a time in the configuration file
   itself or loaded wholesale from an external properties file or an
@@ -1836,7 +1836,7 @@ import ch.qos.logback.classic.LoggerContext;
    </div>
    
 
-   <h4 class="doAnchor" name="scopes">Scopes</h4>
+   <h4 class="doAnchor" id="scopes">Scopes</h4>
 
    <p>A property can be defined for insertion in <em>local scope</em>,
    in <em>context scope</em>, or in <em>system scope</em>. Local scope
@@ -1923,7 +1923,7 @@ import ch.qos.logback.classic.LoggerContext;
    event, even those sent to remote hosts via serialization.</p>
 
 
-  <h3 class="doAnchor" name="defaultValuesForVariables">Default values
+  <h3 class="doAnchor" id="defaultValuesForVariables">Default values
   for variables</h3>
 
   <p>Under certain circumstances, it may be desirable for a variable
@@ -1935,7 +1935,7 @@ import ch.qos.logback.classic.LoggerContext;
   not defined, <code>"${aName<b>:-golden</b>}"</code> will be
   interpreted as "golden".</p>
 
-   <h3 class="doAnchor" name="nestedSubst">Nested variables</h3>
+   <h3 class="doAnchor" id="nestedSubst">Nested variables</h3>
 
    <p>Variable nesting is fully supported. Both the name,
    default-value and value definition of a variable can reference
@@ -2015,20 +2015,20 @@ fileName=myApp.log
 
   <!-- ==============================================================
        -->
-  <h3 class="doAnchor" name="hostname">HOSTNAME property</h3>
+  <h3 class="doAnchor" id="hostname">HOSTNAME property</h3>
 
   <p>As it often comes in handy, the <code>HOSTNAME</code> property is
   defined automatically during configuration with context scope.</p>
 
   <!-- ============================================================== -->
-  <h3 class="doAnchor" name="context_name">CONTEXT_NAME property</h3>
+  <h3 class="doAnchor" id="context_name">CONTEXT_NAME property</h3>
 
   <p>As its name indicates, the <code>CONTEXT_NAME</code> property
   corresponds to the name of the current logging context.</p>
 
   <!-- ============================================================== -->
 
-  <h3 class="doAnchor" name="timestamp">Setting a timestamp</h3>
+  <h3 class="doAnchor" id="timestamp">Setting a timestamp</h3>
 
   <p>The <em>timestamp</em> element can define a property according to
   current date and time. The <em>timestamp</em> element is <a
@@ -2036,7 +2036,7 @@ fileName=myApp.log
   chapter</a>.</p>
 
   <!-- ============================================================== -->
-  <h3 class="doAnchor" name="definingPropsOnTheFly">Defining
+  <h3 class="doAnchor" id="definingPropsOnTheFly">Defining
   variables, aka properties, on the fly</h3>
 
   <p>You may define properties dynamically using the
@@ -2134,7 +2134,7 @@ fileName=myApp.log
 
   <!-- ============================================================== -->
 
-  <h3 class="doAnchor" name="conditional">Conditional processing of
+  <h3 class="doAnchor" id="conditional">Conditional processing of
   configuration files</h3>
 
   <p>Developers often need to juggle between several logback
@@ -2243,7 +2243,7 @@ fileName=myApp.log
 
   <!-- ============================================================== -->
 
-   <h3 class="doAnchor" name="insertFromJNDI">Obtaining variables from
+   <h3 class="doAnchor" id="insertFromJNDI">Obtaining variables from
    JNDI</h3>
 
    <p>Under certain circumstances, you may want to make use of
@@ -2297,7 +2297,7 @@ fileName=myApp.log
   directive.
   </p>
 
-  <h3 class="doAnchor" name="fileInclusion">File inclusion</h3>
+  <h3 class="doAnchor" id="fileInclusion">File inclusion</h3>
 
   <p>Joran supports including parts of a configuration file from
   another file. This is done by declaring a <code>&lt;include></code>
@@ -2388,7 +2388,7 @@ fileName=myApp.log
   <pre><code>&lt;include optional="true" ..../></code></pre>
 
   <!-- ==================== ContextListener =================== -->
-  <h2 class="doAnchor" name="contextListener">Adding a context
+  <h2 class="doAnchor" id="contextListener">Adding a context
   listener</h2>
 
   <p>Instances of the <a
@@ -2404,7 +2404,7 @@ fileName=myApp.log
   </p>
 
   <h3 class="doAnchor"
-  name="LevelChangePropagator">LevelChangePropagator</h3>
+  id="LevelChangePropagator">LevelChangePropagator</h3>
 
   <p>As of version 0.9.25, logback-classic ships with <a
   href="../xref/ch/qos/logback/classic/jul/LevelChangePropagator.html">LevelChangePropagator</a>,
@@ -2471,7 +2471,7 @@ fileName=myApp.log
 
       <p> </p>
 
-   <h3 class="doAnchor" name="sequenceNumberGenerator">SequenceNumberGenerator</h3>    
+   <h3 class="doAnchor" id="sequenceNumberGenerator">SequenceNumberGenerator</h3>    
 
    <p><span class="label">Since 1.3.0</span>Logback supports a
    sequence number field which is automatically populated at event

--- a/src/site/pages/manual/encoders.html
+++ b/src/site/pages/manual/encoders.html
@@ -69,7 +69,7 @@
     needless complexity. However, we hope that with the advent of new
     and powerful encoders this impression will change.</p>
 
-    <h2 class="doAnchor" name="interface">Encoder interface</h2>
+    <h2 class="doAnchor" id="interface">Encoder interface</h2>
 
     <p>Encoders are responsible for transforming an incoming event
     into a byte array <b>and</b> writing out the resulting byte array
@@ -176,13 +176,13 @@ public class LayoutWrappingEncoder&lt;E> extends EncoderBase&lt;E> {
     logback error codes</a>.
     </p>
 
-     <h4 class="doAnchor" name="immediateFlush"><span class="prop">immediateFlush</span> property</h4>
+     <h4 class="doAnchor" id="immediateFlush"><span class="prop">immediateFlush</span> property</h4>
 
      <p>As of <span class="label notice">logback 1.2.0</span>, the
      <span class="prop">immediateFlush</span> property is part of the
      enclosing Appender.</p>
 
-    <h4 class="doAnchor" name="outputPatternAsHeader">Output pattern
+    <h4 class="doAnchor" id="outputPatternAsHeader">Output pattern
     string as header</h4>
 
     <p>In order to facilitate parsing of log files, logback can insert

--- a/src/site/pages/manual/filters.html
+++ b/src/site/pages/manual/filters.html
@@ -57,7 +57,7 @@
 		and turbo filters.
 		</p>
 		
-    <h3 class="doAnchor" name="filter">Regular filters</h3>
+    <h3 class="doAnchor" id="filter">Regular filters</h3>
 
 		<p>Regular logback-classic filters extend the <a
 		href="../xref/ch/qos/logback/core/filter/Filter.html"><code>Filter</code></a>
@@ -91,7 +91,7 @@
     of day or any other part of the logging event.
     </p>
     
-		<h3 class="doAnchor" name="yourOwnFilter">Implementing your own
+		<h3 class="doAnchor" id="yourOwnFilter">Implementing your own
 		Filter</h3>
 		
 		<p>Creating your own filter is easy. All you have to do is extend
@@ -189,7 +189,7 @@ public class SampleFilter extends Filter&lt;ILoggingEvent> {
     <code>AbstractMatcherFilter</code>.
     </p>
 		
-		<h3 class="doAnchor" name="levelFilter">LevelFilter</h3>
+		<h3 class="doAnchor" id="levelFilter">LevelFilter</h3>
 		
 		<p><a href="../xref/ch/qos/logback/classic/filter/LevelFilter.html">
 		<code>LevelFilter</code></a> filters events based on exact level
@@ -236,7 +236,7 @@ public class SampleFilter extends Filter&lt;ILoggingEvent> {
 </div>
 
 
-    <h3 class="doAnchor" name="thresholdFilter">ThresholdFilter</h3>
+    <h3 class="doAnchor" id="thresholdFilter">ThresholdFilter</h3>
 
 		<p>The <a
 		href="../xref/ch/qos/logback/classic/filter/ThresholdFilter.html">
@@ -285,7 +285,7 @@ public class SampleFilter extends Filter&lt;ILoggingEvent> {
 </div>
 
 
-    <h2 class="doAnchor" name="evaluatorFilter">EvaluatorFilter</h2>
+    <h2 class="doAnchor" id="evaluatorFilter">EvaluatorFilter</h2>
 
     <p><a
     href="../xref/ch/qos/logback/core/filter/EvaluatorFilter.html"><code>EvaluatorFilter</code></a>
@@ -309,7 +309,7 @@ public class SampleFilter extends Filter&lt;ILoggingEvent> {
     <!-- ==================== JaninoEventEvaluator ======================== -->
     
     <h3 class="doAnchor"
-    name="JaninoEventEvaluator">JaninoEventEvaluator</h3>
+    id="JaninoEventEvaluator">JaninoEventEvaluator</h3>
     
 
     <p>Logback-classic ships with another concrete
@@ -607,7 +607,7 @@ java chapters.filters.FilterEvents src/main/java/chapters/filters/basicConfigura
 &lt;/evaluator></code></pre>
 
 
- 	  <h2 class="doAnchor" name="matcher">Matchers</h2>
+ 	  <h2 class="doAnchor" id="matcher">Matchers</h2>
 
     <p>While it is possible to do pattern matching by invoking the <a
     href="http://java.sun.com/j2se/1.5.0/docs/api/java/lang/String.html#matches%28java.lang.String%29">matches()</a>
@@ -686,7 +686,7 @@ java chapters.filters.FilterEvents src/main/java/chapters/filters/basicConfigura
     <!-- ===================== TURBO FILTER ============================= -->
     <!-- ================================================================ -->
 
-    <h2 class="doAnchor" name="TurboFilter">TurboFilters</h2>
+    <h2 class="doAnchor" id="TurboFilter">TurboFilters</h2>
     
     <p><code>TurboFilter</code> objects all extend the
     	<a href="../xref/ch/qos/logback/classic/turbo/TurboFilter.html">
@@ -715,7 +715,7 @@ java chapters.filters.FilterEvents src/main/java/chapters/filters/basicConfigura
     </p>
 
    	
-   	<h3 class="doAnchor" name="yourOwnTurboFilter">Implementing your
+   	<h3 class="doAnchor" id="yourOwnTurboFilter">Implementing your
    	own TurboFilter</h3>
     
     <p>To create your own <code>TurboFilter</code> component, just
@@ -942,7 +942,7 @@ public class SampleTurboFilter extends TurboFilter {
 
 		  
     <h3 class="doAnchor"
-    name="DuplicateMessageFilter">DuplicateMessageFilter</h3>
+    id="DuplicateMessageFilter">DuplicateMessageFilter</h3>
 
     <p>The <code>DuplicateMessageFilter</code> merits a separate
     presentation.  This filter detects duplicate messages, and beyond
@@ -1053,7 +1053,7 @@ logger.debug("Hello {}.", name1);</code></pre>
     because only 5 repetitions are allowed by default.
     </p>
 
-    <h1 class="doAnchor" name="logback-access">In logback-access</h1>
+    <h1 class="doAnchor" id="logback-access">In logback-access</h1>
     
     <p>Logback-access offers most of the features available with
     logback-classic. In particular, <code>Filter</code> objects are
@@ -1068,7 +1068,7 @@ logger.debug("Hello {}.", name1);</code></pre>
     </p>
 
 		<h2 class="doAnchor"
-		name="countingFilter"><code>CountingFilter</code></h2>
+		id="countingFilter"><code>CountingFilter</code></h2>
 		
 		<p>With the help of <a
 		href="../xref/ch/qos/logback/access/filter/CountingFilter.html"><code>CountingFilter</code></a>
@@ -1123,7 +1123,7 @@ logger.debug("Hello {}.", name1);</code></pre>
     <img alt="CountingFilter via jconsole" src="images/chapters/filters/countingFilter.png" />
 	
 
-    <h3 class="doAnchor" name="access_EvaluatorFilter">EvaluatorFilter</h3>
+    <h3 class="doAnchor" id="access_EvaluatorFilter">EvaluatorFilter</h3>
 
     
     <p><a

--- a/src/site/pages/manual/groovy.html
+++ b/src/site/pages/manual/groovy.html
@@ -113,14 +113,14 @@
     <em>info</em> without a static import statement.</p>
 
 
-    <h2 class="doAnchor" name="sift">SiftingAppender no longer supported</h2>
+    <h2 class="doAnchor" id="sift">SiftingAppender no longer supported</h2>
 
     <p><span class="label">Since version 1.0.12</span>
     <code>SiftingAppender</code> is no longer supported within groovy
     configuration files. However, in case there is demand, it may be
     re-introduced.</p>
 
-    <h2 class="doAnchor" name="extensions">Extensions specific to
+    <h2 class="doAnchor" id="extensions">Extensions specific to
     <em>logback.groovy</em></h2>
 
     <p><span class="green">Essentially, <em>Logback.groovy</em> syntax
@@ -359,7 +359,7 @@ root(DEBUG, ["STDOUT"])</pre>
 
     <!-- ========================================================== -->
 
-    <h2 class="doAnchor" name="internalDSL">Internal DSL, i.e. it's
+    <h2 class="doAnchor" id="internalDSL">Internal DSL, i.e. it's
     all groovy baby!</h2>
 
     <p>The <em>logback.groovy</em> is an internal DSL meaning that its
@@ -373,7 +373,7 @@ root(DEBUG, ["STDOUT"])</pre>
     </p>
 
 
-    <h3 class="doAnchor" name="varedef">Variable definitions and
+    <h3 class="doAnchor" id="varedef">Variable definitions and
     GStrings</h3>
 
     <p>You can define variables anywhere within a
@@ -394,7 +394,7 @@ appender("FILE", FileAppender) {
 root(DEBUG, ["FILE"])</pre>
 
 
-    <h3 class="doAnchor" name="printing">Printing on the console</h3>
+    <h3 class="doAnchor" id="printing">Printing on the console</h3>
 
     <p>You can invoke Groovy's <code>println</code> method to print on
     the console. Here is an example.</p>
@@ -412,10 +412,10 @@ appender("FILE", FileAppender) {
 root(DEBUG, ["FILE"])</pre>
 
 
-   <h3 class="doAnchor" name="automaticallyExported">Automatically
+   <h3 class="doAnchor" id="automaticallyExported">Automatically
    exported fields</h3>
 
-   <h4 class="doAnchor" name="hostname">'hostname' variable</h4>
+   <h4 class="doAnchor" id="hostname">'hostname' variable</h4>
 
    <p>The 'hostname' variable contains the name of the current
    host. However, due to scoping rules that the authors cannot fully
@@ -447,7 +447,7 @@ appender("STDOUT", ConsoleAppender) {
 }</pre>
 
 
-   <h3 class="doAnchor" name="everythingIsContext">Everything is
+   <h3 class="doAnchor" id="everythingIsContext">Everything is
    context aware with a reference to the current context</h3>
 
    <p>The execution of the <em>logback.groovy</em> script is done

--- a/src/site/pages/manual/introduction.html
+++ b/src/site/pages/manual/introduction.html
@@ -59,8 +59,7 @@
 
     <script src="../templates/setup.js" type="text/javascript"></script>
     
-    <a name="Requirements"></a>
-    <h3>Requirements</h3>
+    <h3 id="Requirements">Requirements</h3>
 
     <p>Logback-classic module requires the presence of
     <em>slf4j-api.jar</em> and <em>logback-core.jar</em> in addition to
@@ -224,7 +223,7 @@ public class HelloWorld2 {
   </ol>
  
   
-  <h2 class="doAnchor" name="building">Building logback</h2>
+  <h2 class="doAnchor" id="building">Building logback</h2>
   
   <p>As its build tool, logback relies on <a
   href="http://maven.apache.org">Maven</a>, a widely-used open-source

--- a/src/site/pages/manual/introduction1.html
+++ b/src/site/pages/manual/introduction1.html
@@ -202,8 +202,7 @@
 
     <!--    <script src="../templates/setup.js" type="text/javascript"></script>-->
 
-    <a name="Requirements"></a>
-    <h3>Requirements</h3>
+    <h3 id="Requirements">Requirements</h3>
     <p>Logback-classic module requires the presence of
         <em>slf4j-api.jar</em> and <em>logback-core.jar</em> in addition to
         <em>logback-classic.jar</em> on the classpath.

--- a/src/site/pages/manual/jmxConfig.html
+++ b/src/site/pages/manual/jmxConfig.html
@@ -72,7 +72,7 @@
     in the figure below:
     </p>
     
-    <h3 class="doAnchor" name="jmxConfigurator">Screen-shot of
+    <h3 class="doAnchor" id="jmxConfigurator">Screen-shot of
     <code>JMXConfigurator</code> viewed in <code>jconsole</code></h3>
 
     <img src="images/chapters/jmxConfigurator/jmxConfigurator.gif" alt="jmxConfigurator"/>   
@@ -102,7 +102,7 @@
 
     <img src="images/chapters/jmxConfigurator/statusList.gif" alt="statusList.gif"/>   
 
-    <h3 class="doAnchor" name="leak">Avoiding memory leaks</h3>
+    <h3 class="doAnchor" id="leak">Avoiding memory leaks</h3>
 
     <p>If your application is deployed in a web-server or an
     application server, the registration of an
@@ -142,7 +142,7 @@ public class MyContextListener implements ServletContextListener {
     <!-- ============ Multiple web-applications  ================== -->
 
     
-    <h2 class="doAnchor" name="multiple"><code>JMXConfigurator</code>
+    <h2 class="doAnchor" id="multiple"><code>JMXConfigurator</code>
     with multiple web-applications</h2>
 
     <p>If you deploy multiple web-applications in the same server,
@@ -194,7 +194,7 @@ public class MyContextListener implements ServletContextListener {
     
     <!-- ============ JMX enabling your  server ================== -->
 
-    <h3 class="doAnchor" name="jmxEnablingServer">JMX enabling your
+    <h3 class="doAnchor" id="jmxEnablingServer">JMX enabling your
     server</h3>
 
     <p>If your server runs with JDK 1.6 or later, your server should

--- a/src/site/pages/manual/layouts.html
+++ b/src/site/pages/manual/layouts.html
@@ -69,7 +69,7 @@
       <code>ch.qos.logback.classic.&#8203;spi.ILoggingEvent</code></a>.  This
 			fact will be apparent throughout this section.</p>
 
-		<h2 class="doAnchor" name="writingYourOwnLayout">Writing your own
+		<h2 class="doAnchor" id="writingYourOwnLayout">Writing your own
 		custom Layout</h2>
 
 		<p>Let us implement a simple yet functional layout for the
@@ -142,7 +142,7 @@ public class MySampleLayout extends LayoutBase&lt;ILoggingEvent> {
 		contents of exceptions as well.
 		</p>
 
-    <h3 class="doAnchor" name="configuringYourOwnLayout">Configuring
+    <h3 class="doAnchor" id="configuringYourOwnLayout">Configuring
     your custom layout</h3>
 
 		<p>Custom layouts are configured as any other component. As
@@ -308,7 +308,7 @@ public class MySampleLayout2 extends LayoutBase&lt;ILoggingEvent> {
    <p></p>
 
 
-     <h2 class="doAnchor" name="ClassicPatternLayout">PatternLayout</h2>
+     <h2 class="doAnchor" id="ClassicPatternLayout">PatternLayout</h2>
 
      <p>Logback classic ships with a flexible layout called <a
      href="../xref/ch/qos/logback/classic/PatternLayout.html">
@@ -439,8 +439,7 @@ WARN  [main]: Message 2</p>
       </tr>
 
 			<tr>
-				<td class="word" name="logger">
-          <a name="logger" href="#logger"><span class="anchor"/></a>
+				<td class="word" id="logger">
 					<b>c</b>{<em>length</em>} <br />
 					<b>lo</b>{<em>length</em>} <br />
 					<b>logger</b>{<em>length</em>} <br />
@@ -518,7 +517,7 @@ WARN  [main]: Message 2</p>
 			</tr>
 
 			<tr>
-				<td class="word" name="class">
+				<td class="word" id="class">
 					<b>C</b>{<em>length</em>} <br />
 					<b>class</b>{<em>length</em>} <br />
 				</td>
@@ -543,14 +542,14 @@ WARN  [main]: Message 2</p>
 			</tr>
 
       <tr>
-        <td class="word" name="contextName">
+        <td class="word" id="contextName">
           <b>contextName</b><br/>
           <b>cn</b><br/></td>
           <td>Outputs the name of the logger context to which the
           logger at the origin of the event was attached to. </td>
       </tr>
       <tr>
-        <td class="word" name="date">
+        <td class="word" id="date">
           <b>d</b>{<em>pattern</em>} <br />
           <b>date</b>{<em>pattern</em>} <br />
           <b>d</b>{<em>pattern</em>, <em>timezone</em>} <br />
@@ -645,7 +644,7 @@ WARN  [main]: Message 2</p>
          </tr>
 
         <tr>
-          <td class="word" name="micros">
+          <td class="word" id="micros">
             <b>micros / ms</b>
           </td>
           <td><p><span class="label notice">Since 1.3</span> Outputs the microseconds of the timestamp included in
@@ -658,7 +657,7 @@ WARN  [main]: Message 2</p>
 
 
 			<tr>
-				<td class="word" name="file">
+				<td class="word" id="file">
 					<b>F / file</b>
 				</td>
 
@@ -675,7 +674,7 @@ WARN  [main]: Message 2</p>
 			</tr>
 
 			<tr >
-				<td class="word" name="caller">
+				<td class="word" id="caller">
 					<b>caller{depth}</b>
 					<b>caller{depthStart..depthEnd}</b>
 					<b>caller{depth, evaluator-1, ... evaluator-n}</b>
@@ -735,7 +734,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 			</tr>
 
 		<tr>
-		  <td class="word" name="kvp">
+		  <td class="word" id="kvp">
 		    <b>kvp{NONE,SINGLE,DOUBLE}</b>
 		  </td>
 		  <td>
@@ -773,7 +772,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 
 
 		<tr>
-		  <td class="word" name="line">
+		  <td class="word" id="line">
 		    <b>L / line</b>
 		  </td>
 
@@ -789,7 +788,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 
 
 		<tr>
-		  <td class="word" name="message">
+		  <td class="word" id="message">
 		    <b>m / msg / message</b>
 		  </td>
 		  <td>
@@ -800,7 +799,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 		</tr>
 
 		<tr>
-		  <td class="word" name="method">
+		  <td class="word" id="method">
 		    <b>M / method</b>
 		  </td>
 
@@ -814,7 +813,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 		</tr>
 
 		<tr>
-		  <td class="word" name="newline">
+		  <td class="word" id="newline">
 		    <b>n</b>
 		  </td>
 
@@ -831,7 +830,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 			</tr>
 
 			<tr>
-				<td class="word" name="level">
+				<td class="word" id="level">
 					<b>p / le / level</b>
 				</td>
 				<td>Outputs the level of the logging event.</td>
@@ -839,7 +838,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 
 			<tr>
 
-				<td class="word" name="relative">
+				<td class="word" id="relative">
 					<b>r / relative</b>
 				</td>
 
@@ -850,7 +849,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 
 
 			<tr>
-				<td class="word" name="relative">
+				<td class="word" id="relative">
 					<b>t / thread</b>
 				</td>
 
@@ -861,7 +860,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 			</tr>
 
 			<tr>
-				<td class="word" name="mdc">
+				<td class="word" id="mdc">
 					<b>X</b>{<em>key:-defaultVal</em>} <br />
 					<b>mdc</b>{<em>key:-defaultVal</em>} <br />
 				</td>
@@ -892,7 +891,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 				</td>
 			</tr>
 			<tr>
-				<td class="word" name="ex">
+				<td class="word" id="ex">
 					<b>ex</b>{<em>depth</em>} <br />
           	<b>exception</b>{<em>depth</em>} <br />
 					<b>throwable</b>{<em>depth</em>} <br />
@@ -975,7 +974,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
       </tr>
 
       <tr>
-	<td class="word" name="xThrowable">
+	<td class="word" id="xThrowable">
 	  <b>xEx</b>{<em>depth</em>} <br />
           <b>xException</b>{<em>depth</em>} <br />
 					<b>xThrowable</b>{<em>depth</em>} <br />
@@ -1043,7 +1042,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
       </tr>
 
       <tr>
-        <td class="word" name="nopex">
+        <td class="word" id="nopex">
           <b>nopex</b> <br />
           <b>nopexception</b>
         </td>
@@ -1063,7 +1062,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
       </tr>
 
       <tr >
-        <td class="word" name="marker">
+        <td class="word" id="marker">
           <b>marker</b>
         </td>
 
@@ -1083,7 +1082,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 
 
       <tr>
-        <td class="word" name="property">
+        <td class="word" id="property">
           <b>property{key}</b>
         </td>
 
@@ -1109,7 +1108,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
       </tr>
 
       <tr>
-        <td class="word" name="replace">
+        <td class="word" id="replace">
           <b>replace(<em>p</em>){r, t}</b>
         </td>
 
@@ -1131,7 +1130,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
       </tr>
 
       <tr>
-        <td class="word" name="prefix">
+        <td class="word" id="prefix">
           <b>prefix(<em>p</em>)</b>
         </td>
 
@@ -1161,7 +1160,7 @@ Caller+0   at mainPackage.sub.;sample.Bar.createLoggingRequest(;Bar.java:17)</pr
 
 
       <tr>
-        <td class="word" name="rootException">
+        <td class="word" id="rootException">
           <b>rEx</b>{<em>depth</em>} <br />
           <b>rootException</b>{<em>depth</em>} <br />
           <br />
@@ -1202,7 +1201,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
 		</table>
 
 
-    <h4 class="doAnchor" name="percentIsSpecial">% character has special meaning</h4>
+    <h4 class="doAnchor" id="percentIsSpecial">% character has special meaning</h4>
 
     <p>Given that in the context of conversion patterns the percent
     sign carries special meaning, in order to include it as a literal,
@@ -1210,7 +1209,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
     %m%n".
     </p>
 
-    <h4 class="doAnchor" name="restrictionsOnLiterals">Restrictions on
+    <h4 class="doAnchor" id="restrictionsOnLiterals">Restrictions on
     literals immediately following conversion words</h4>
 
     <p>In most cases literals naturally contain spaces or other
@@ -1232,7 +1231,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
 
     </p>
 
-    <h2 class="doAnchor" name="formatModifiers">Format modifiers</h2>
+    <h2 class="doAnchor" id="formatModifiers">Format modifiers</h2>
 
 		<p>By default the relevant information is output as-is.  However,
 		with the aid of format modifiers it is possible to change the
@@ -1386,7 +1385,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
 			</tr>
 		</table>
 
-    <h3 class="doAnchor" name="oneLetterLevel">Output just one letter
+    <h3 class="doAnchor" id="oneLetterLevel">Output just one letter
     for the level</h3>
 
     <p>Instead of printing TRACE, DEBUG, WARN, INFO or ERROR for the
@@ -1398,7 +1397,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
     "<code>%.-1level</code>".
     </p>
 
-		<h2 class="doAnchor" name="cwOptions">Conversion word options</h2>
+		<h2 class="doAnchor" id="cwOptions">Conversion word options</h2>
 
 		<p>A conversion specifier can be followed by options. They are
 		always declared between braces. We have already seen some of the
@@ -1430,7 +1429,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
     previous item at least 14 but at most 16 times.
     </p>
 
-    <h2 class="doAnchor" name="grouping">Grouping with
+    <h2 class="doAnchor" id="grouping">Grouping with
       parentheses</h2>
 
     <p>In logback, parentheses within the pattern string are treated
@@ -1480,7 +1479,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
     [%thread]<b>\)</b>.
     </p>
 
-    <h2 class="doAnchor" name="coloring">Coloring</h2>
+    <h2 class="doAnchor" id="coloring">Coloring</h2>
 
     <p>Grouping by <a href="#Parentheses">parentheses</a> as explained
     above allows coloring of sub-patterns. As of version 1.0.5,
@@ -1560,7 +1559,7 @@ Wrapped by: org.springframework.;BeanCreationException: Error creating bean with
     specifier</a> discusses the steps necessary for registering a
     conversion word in your configuration file.</p>
 
-		<h2 class="doAnchor" name="Evaluators">Evaluators</h2>
+		<h2 class="doAnchor" id="Evaluators">Evaluators</h2>
 
 		<p>As mentioned above, option lists come in handy when a
 		conversion specifier is required to behave dynamically based on
@@ -1853,7 +1852,7 @@ java.lang.Exception: display
 
 
 
-		<h2 class="doAnchor" name="customConversionSpecifier">Creating a
+		<h2 class="doAnchor" id="customConversionSpecifier">Creating a
 		custom conversion specifier</h2>
 
 		<p>Up to this point we have presented the built-in conversion
@@ -1964,7 +1963,7 @@ java.lang.Exception: display
 
 
 
-    <h2 class="doAnchor" name="ClassicHTMLLayout">HTMLLayout</h2>
+    <h2 class="doAnchor" id="ClassicHTMLLayout">HTMLLayout</h2>
 
 	  <p><a
 	  href="../xref/ch/qos/logback/classic/html/HTMLLayout.html"><code>HTMLLayout</code></a>
@@ -2099,7 +2098,7 @@ java.lang.Exception: display
 		</p>
 
 
-    <h2 class="doAnchor" name="log4jXMLLayout">Log4j XMLLayout</h2>
+    <h2 class="doAnchor" id="log4jXMLLayout">Log4j XMLLayout</h2>
 
     <p><a
     href="../xref/ch/qos/logback/classic/log4j/XMLLayout.html">XMLLayout</a>
@@ -2155,7 +2154,7 @@ java.lang.Exception: display
   <p>Requires a server call. Please wait a few seconds.</p>
 </div>
 
-		<h1 class="doAnchor" name="logback-access">Logback access</h1>
+		<h1 class="doAnchor" id="logback-access">Logback access</h1>
 
 		<p>Most logback-access layouts are mere adaptations of
 		logback-classic layouts. Logback-classic and logback-access
@@ -2169,7 +2168,7 @@ java.lang.Exception: display
 		logback-classic.</p>
 
 
-		<h3 class="doAnchor" name="AccessPatternLayout">PatternLayout</h3>
+		<h3 class="doAnchor" id="AccessPatternLayout">PatternLayout</h3>
 
 		<p><a href="../xref/ch/qos/logback/access/PatternLayout.html">
 		<code>PatternLayout</code></a> in logback-access can be configured
@@ -2188,7 +2187,7 @@ java.lang.Exception: display
         <th align="center">Effect</th>
       </tr>
       <tr>
-        <td class="word" name="remoteIP">
+        <td class="word" id="remoteIP">
           <b>a / remoteIP</b>
         </td>
         <td>
@@ -2196,13 +2195,13 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="localIP"><b>A / localIP</b></td>
+        <td class="word" id="localIP"><b>A / localIP</b></td>
         <td>
           <p>Local IP address.</p>
         </td>
       </tr>
       <tr>
-        <td class="word" name="bytesSent"><b>b / B / bytesSent</b></td>
+        <td class="word" id="bytesSent"><b>b / B / bytesSent</b></td>
         <td>
           <p>
             Response's content length.
@@ -2210,7 +2209,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="clientHost"><b>h / clientHost</b></td>
+        <td class="word" id="clientHost"><b>h / clientHost</b></td>
         <td>
           <p>
             Remote host.
@@ -2218,13 +2217,13 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="protocol"><b>H / protocol</b></td>
+        <td class="word" id="protocol"><b>H / protocol</b></td>
         <td>
           <p>Request protocol.</p>
         </td>
       </tr>
       <tr>
-        <td class="word" name="remoteLogName"><b>l</b></td>
+        <td class="word" id="remoteLogName"><b>l</b></td>
         <td>
           <p>
             Remote log name. In logback-access, this converter always
@@ -2234,7 +2233,7 @@ java.lang.Exception: display
       </tr>
 
       <tr>
-        <td class="word" name="reqParameter"><b>reqParameter{paramName}</b></td>
+        <td class="word" id="reqParameter"><b>reqParameter{paramName}</b></td>
         <td>
           <p>Parameter of the response.</p>
           <p>This conversion word takes the first option in braces and looks
@@ -2244,7 +2243,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="header"><b>i{header} / header{header}</b></td>
+        <td class="word" id="header"><b>i{header} / header{header}</b></td>
         <td>
           <p>Request header.</p>
           <p>This conversion word takes the first option in braces and looks
@@ -2256,13 +2255,13 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr >
-        <td class="word" name="requestMethod"><b>m / requestMethod</b></td>
+        <td class="word" id="requestMethod"><b>m / requestMethod</b></td>
         <td>
           <p>Request method.</p>
         </td>
       </tr>
       <tr>
-        <td class="word" name="requestURL"><b>r / requestURL</b></td>
+        <td class="word" id="requestURL"><b>r / requestURL</b></td>
         <td>
           <p>
             URL requested.
@@ -2270,7 +2269,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="statusCode"><b>s / statusCode</b></td>
+        <td class="word" id="statusCode"><b>s / statusCode</b></td>
         <td>
           <p>
             Status code of the request.
@@ -2278,7 +2277,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-          <td class="word" name="elapsedTime"><b>D / elapsedTime</b></td>
+          <td class="word" id="elapsedTime"><b>D / elapsedTime</b></td>
           <td>
               <p>
                   The time taken to serve the request, in milliseconds.
@@ -2286,7 +2285,7 @@ java.lang.Exception: display
           </td>
       </tr>
       <tr>
-        <td class="word" name="elapsedSeconds"><b>T / elapsedSeconds</b></td>
+        <td class="word" id="elapsedSeconds"><b>T / elapsedSeconds</b></td>
         <td>
           <p>
             The time taken to serve the request, in seconds.
@@ -2294,7 +2293,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="dateAccess"><b>t / date</b></td>
+        <td class="word" id="dateAccess"><b>t / date</b></td>
         <td>
           <p>Outputs the date of the logging event.  The date
           conversion specifier may be followed by a set of braces
@@ -2310,7 +2309,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="httpUser"><b>u / user</b></td>
+        <td class="word" id="httpUser"><b>u / user</b></td>
         <td>
           <p>
             Remote user.
@@ -2318,7 +2317,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="queryString"><b>q / queryString</b></td>
+        <td class="word" id="queryString"><b>q / queryString</b></td>
         <td>
           <p>
             Request query string, prepended with a '?'.
@@ -2326,7 +2325,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="requestURI"><b>U / requestURI</b></td>
+        <td class="word" id="requestURI"><b>U / requestURI</b></td>
         <td>
           <p>
             Requested URI.
@@ -2334,31 +2333,31 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr>
-        <td class="word" name="sessionID"><b>S / sessionID</b></td>
+        <td class="word" id="sessionID"><b>S / sessionID</b></td>
         <td>
           <p>Session ID.</p>
         </td>
       </tr>
       <tr >
-        <td class="word" name="server"><b>v / server</b></td>
+        <td class="word" id="server"><b>v / server</b></td>
         <td>
           <p>Server name.</p>
         </td>
       </tr>
       <tr>
-        <td class="word" name="threadName"><b>I / threadName</b></td>
+        <td class="word" id="threadName"><b>I / threadName</b></td>
         <td>
           <p>Name of the thread which processed the request.</p>
         </td>
       </tr>
       <tr class="b">
-        <td class="word" name="localPort"><b>localPort</b></td>
+        <td class="word" id="localPort"><b>localPort</b></td>
         <td>
           <p>Local port.</p>
         </td>
       </tr>
       <tr class="a">
-        <td class="word" name="reqAttribute"><b>reqAttribute{attributeName}</b></td>
+        <td class="word" id="reqAttribute"><b>reqAttribute{attributeName}</b></td>
         <td>
           <p>Attribute of the request.</p>
           <p>This conversion word takes the first option in braces and looks
@@ -2368,7 +2367,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr class="b">
-        <td class="word" name="reqCookie"><b>reqCookie{cookie}</b></td>
+        <td class="word" id="reqCookie"><b>reqCookie{cookie}</b></td>
         <td>
           <p>Request cookie.</p>
           <p>This conversion word takes the first option in braces and looks
@@ -2377,7 +2376,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr class="a">
-        <td class="word" name="responseHeader"><b>responseHeader{header}</b></td>
+        <td class="word" id="responseHeader"><b>responseHeader{header}</b></td>
         <td>
           <p>
             Header of the response.
@@ -2388,7 +2387,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr class="b">
-        <td class="word" name="requestContent"><b>requestContent</b></td>
+        <td class="word" id="requestContent"><b>requestContent</b></td>
         <td>
           <p>This conversion word displays the content of the request,
           that is the request's <code>InputStream</code>. It is used
@@ -2405,7 +2404,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr class="a">
-        <td class="word" name="fullRequest"><b>fullRequest</b></td>
+        <td class="word" id="fullRequest"><b>fullRequest</b></td>
         <td>
           <p>This converter outputs the data associated with the
           request, including all headers and request contents.
@@ -2413,7 +2412,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr class="b">
-        <td class="word" name="responseContent"><b>responseContent</b></td>
+        <td class="word" id="responseContent"><b>responseContent</b></td>
         <td>
           <p>This conversion word displays the content of the
           response, that is the response's
@@ -2430,7 +2429,7 @@ java.lang.Exception: display
         </td>
       </tr>
       <tr class="a">
-        <td class="word" name="fullResponse"><b>fullResponse</b></td>
+        <td class="word" id="fullResponse"><b>fullResponse</b></td>
         <td>
           <p>This conversion word takes all the available data
           associated with the response, including all headers of the
@@ -2469,7 +2468,7 @@ java.lang.Exception: display
 	 	begins much like the <em>common</em> pattern but also displays two
 	 	request headers, namely referer, and user-agent.</p>
 
-		<h3 class="doAnchor" name="AccessHTMLLayout">HTMLLayout</h3>
+		<h3 class="doAnchor" id="AccessHTMLLayout">HTMLLayout</h3>
 
 		<p>The <a
 		href="../xref/ch/qos/logback/access/html/HTMLLayout.html"><code>HTMLLayout</code></a>

--- a/src/site/pages/manual/loggingSeparation.html
+++ b/src/site/pages/manual/loggingSeparation.html
@@ -63,7 +63,7 @@
     of the container itself.
     </p>
 
-    <h2 class="doAnchor" name="easy">The simplest and easiest
+    <h2 class="doAnchor" id="easy">The simplest and easiest
     approach</h2>
 
     <p>Assuming your container supports child-first class loading,
@@ -94,7 +94,7 @@
     separation impossible. All hope is not lost. Please read on.
     </p>
 
-    <h2 class="doAnchor" name="contextSelectors">Context
+    <h2 class="doAnchor" id="contextSelectors">Context
     Selectors</h2>
 
     <p>Logback provides a mechanism for a single instance of SLF4J and
@@ -139,7 +139,7 @@
 
 
     <h3 class="doAnchor"
-    name="ContextJNDISelector">ContextJNDISelector</h3>
+    id="ContextJNDISelector">ContextJNDISelector</h3>
 
     <p>Logback-classic ships with a selector called
     <code>ContextJNDISelector</code> which selects the logger context
@@ -163,7 +163,7 @@
     for
     <code>ch.qos.logback.classic.&#8203;selector.ContextJNDISelector</code>.</p>
 
-    <h3 class="doAnchor" name="settingJNDIVariables">Setting JNDI
+    <h3 class="doAnchor" id="settingJNDIVariables">Setting JNDI
     variables in applications</h3>
     
     <p>In each of your applications, you need to name the logging
@@ -211,7 +211,7 @@
     </p>
     
 
-    <h3 class="doAnchor" name="jndiTomcat">Configuring Tomcat for
+    <h3 class="doAnchor" id="jndiTomcat">Configuring Tomcat for
     ContextJNDISelector</h3>
 
     <p>First, place the logback jars (that is
@@ -230,7 +230,7 @@
     <p class="source">JAVA_OPTS="$JAVA_OPTS -Dlogback.ContextSelector=&#8203;JNDI"</p>
 
 
-    <h3 class="doAnchor" name="hotDeploy">Hot deploying
+    <h3 class="doAnchor" id="hotDeploy">Hot deploying
     applications</h3>
 
     <p>When the web-application is recycled or shutdown, we strongly
@@ -259,7 +259,7 @@
     <code>contextDestroyed()</code> method is invoked <em>last</em>
     during application shutdown. </p>
 
-    <h3 class="doAnchor" name="betterPerf">Better performance</h3>
+    <h3 class="doAnchor" id="betterPerf">Better performance</h3>
 
     <p>When <code>ContextJNDISelector</code> is active, each time a
     logger is retrieved, a JNDI lookup must be performed. This can
@@ -296,7 +296,7 @@
    recycled.</p>
 
 
-   <h2 class="doAnchor" name="tamingStaticRefs">Taming static
+   <h2 class="doAnchor" id="tamingStaticRefs">Taming static
    references in shared libraries</h2>
 
    <p><code>ContextJNDISelector</code> works nicely to create logging

--- a/src/site/pages/manual/mdc.html
+++ b/src/site/pages/manual/mdc.html
@@ -497,7 +497,7 @@ public class NumberCruncherServer extends UnicastRemoteObject
 		
 		
 		
-		<h3 class="doAnchor" name="autoMDC">Automating access to the <code>MDC</code></h3>
+		<h3 class="doAnchor" id="autoMDC">Automating access to the <code>MDC</code></h3>
 		
 		<p>As we've seen, the <code>MDC</code> is very useful when dealing
 			with multiple clients. In the case of a web application that
@@ -615,7 +615,7 @@ public class UserServletFilter implements Filter {
 		
 
 
-  <h3 class="doAnchor" name="managedThreads">MDC And Managed
+  <h3 class="doAnchor" id="managedThreads">MDC And Managed
   Threads</h3>
 
   <p>A copy of the mapped diagnostic context can not always be
@@ -635,7 +635,7 @@ public class UserServletFilter implements Filter {
   managed thread.
   </p>
 
-  <h3 class="doAnchor" name="mis">MDCInsertingServletFilter</h3>
+  <h3 class="doAnchor" id="mis">MDCInsertingServletFilter</h3>
 
   <p>Within web applications, it often proves helpful to know the
   hostname, request uri and user-agent associated with a given HTTP

--- a/src/site/pages/manual/migrationFromLog4j.html
+++ b/src/site/pages/manual/migrationFromLog4j.html
@@ -66,7 +66,7 @@
     </p>
 
     
-    <h3 class="doAnchor" name="log4jLayout">Migrating a log4j layout</h3>
+    <h3 class="doAnchor" id="log4jLayout">Migrating a log4j layout</h3>
 
     <p>Let us begin by migrating a hypothetical and trivially simple
     log4j layout named <a
@@ -137,7 +137,7 @@ public class TrivialLogbackLayout extends <b>LayoutBase&lt;ILoggingEvent></b> {
    <code>activateOptions</code>() method.
    </p>
 
-   <h3 class="doAnchor" name="log4jAppender">Migrating a log4j
+   <h3 class="doAnchor" id="log4jAppender">Migrating a log4j
    appender</h3>
    
    <p>Migrating an appender is quite similar to migrating a

--- a/src/site/pages/manual/onJoran.html
+++ b/src/site/pages/manual/onJoran.html
@@ -125,7 +125,7 @@
     exact matches and wildcard matches.
     </p>
 
-    <h3 class="doAnchor" name="saxOrDom">SAX or DOM?</h3>
+    <h3 class="doAnchor" id="saxOrDom">SAX or DOM?</h3>
 
     <p>Due to the event-based architecture of the SAX API, a tool based
     on SAX cannot easily deal with forward references, that is,
@@ -159,7 +159,7 @@
     </p>
 
 
-    <h3 class="doAnchor" name="pattern">Pattern</h3>
+    <h3 class="doAnchor" id="pattern">Pattern</h3>
 
     <p>A Joran pattern is essentially a string. There are two kind of
     patterns, <em>exact</em> and <em>wildcard</em>. The pattern "a/b"
@@ -176,7 +176,7 @@
     <code>&lt;a></code> element.
     </p>
 
-    <h3 class="doAnchor" name="action">Actions</h3>
+    <h3 class="doAnchor" id="action">Actions</h3>
     
     <p>As mentioned above, Joran parsing rules consists of the
     association of patterns. Actions extend the <a
@@ -222,7 +222,7 @@ public abstract class Action extends ContextAwareBase {
    empty/nop implementation provided by <code>Action</code>.</p>
 
 
-   <h3 class="doAnchor" name="ruleStore">RuleStore </h3>
+   <h3 class="doAnchor" id="ruleStore">RuleStore </h3>
 
    <p>As mentioned previously, the invocation of actions according to
    matching patterns is a central concept in Joran. A rule is an
@@ -249,7 +249,7 @@ public abstract class Action extends ContextAwareBase {
    </p>
    
 
-   <h3 class="doAnchor" name="interpretationContext">Interpretation
+   <h3 class="doAnchor" id="interpretationContext">Interpretation
    context</h3>
 
    <p>To allow various actions to collaborate, the invocation of begin
@@ -269,7 +269,7 @@ public abstract class Action extends ContextAwareBase {
    <code>StatusManager</code>.
    </p>
    
-   <h3 class="doAnchor" name="helloWorld">Hello world</h3>
+   <h3 class="doAnchor" id="helloWorld">Hello world</h3>
    
    <p>The first example in this chapter illustrates the minimal
    plumbing required for using Joran. The example consists of a
@@ -318,7 +318,7 @@ public abstract class Action extends ContextAwareBase {
 
     <!-- =================&#8203;================&#8203;================&#8203;===== -->
 
-    <h3 class="doAnchor" name="calculator">Collaborating actions</h3>
+    <h3 class="doAnchor" id="calculator">Collaborating actions</h3>
    
     <p>The <em>logback-examples/&#8203;src/main/java/joran/&#8203;calculator/</em>
     directory includes several actions which collaborate together
@@ -485,7 +485,7 @@ public abstract class Action extends ContextAwareBase {
   <code>end()</code> method.</p>
   -->
 
-  <h3 class="doAnchor" name="implicit">Implicit actions</h3>
+  <h3 class="doAnchor" id="implicit">Implicit actions</h3>
 
   <p>The rules defined thus far are called explicit actions because a
   pattern/action association could be found in the rule store for the
@@ -586,7 +586,7 @@ Element [abc] asked to be printed.
   above (see previous paragraph).
   </p>
 
-  <h3 class="doAnchor" name="iaPractice">Implicit actions in
+  <h3 class="doAnchor" id="iaPractice">Implicit actions in
   practice</h3>
   
   <p>The respective Joran configurators of logback-classic and
@@ -645,7 +645,7 @@ Element [abc] asked to be printed.
     </li>
   </ol>
 
-  <h4 class="doAnchor" name="defaultClassMapping">Default class
+  <h4 class="doAnchor" id="defaultClassMapping">Default class
   mapping</h4>
 
   <p>In logback-classic, there are a handful of internal rules mapping
@@ -715,7 +715,7 @@ Element [abc] asked to be printed.
   properties, be they simple or complex. Instead of a setter method,
   the property is specified by an "adder" method.</p>
 
-  <h3 class="doAnchor" name="newRule">New rules on the fly</h3>
+  <h3 class="doAnchor" id="newRule">New rules on the fly</h3>
 
   <p>Joran includes an action which allows the Joran interpreter to
   learn new rules on the fly, that is while interpreting an XML

--- a/src/site/pages/manual/receivers.html
+++ b/src/site/pages/manual/receivers.html
@@ -37,7 +37,7 @@
       <script src="../templates/creative.js" type="text/javascript"></script>
       <script src="../templates/setup.js" type="text/javascript"></script>
     
-      <h2 class="doAnchor" name="whatIsAReceiver">What is a Receiver?</h2>
+      <h2 class="doAnchor" id="whatIsAReceiver">What is a Receiver?</h2>
     
       <p>A <em>receiver</em> is a Logback component that receives logging
       events from a remote appender and logs each received event according
@@ -112,7 +112,7 @@
       listen on a distinct port, and each receiver acting in the client
       role will connect to exactly one remote appender.</p>
     
-      <h2 class="doAnchor" name="receiverServerComponents">Receivers
+      <h2 class="doAnchor" id="receiverServerComponents">Receivers
       that Act in the Server Role</h2>
     
       <p>A receiver that is configured to act in the server role passively
@@ -172,7 +172,7 @@
       </table>
     </div>
 
-      <h3 class="doAnchor" name="usingServerSocketReceiver">Using
+      <h3 class="doAnchor" id="usingServerSocketReceiver">Using
       ServerSocketReceiver</h3>
     
       <p>The following configuration uses the 
@@ -249,7 +249,7 @@
       <a href="../xref/chapters/receivers/socket/AppenderExample.html">chapters.receivers.socket.AppenderExample </a>\
       src/main/java/chapters/&#8203;receivers/socket/&#8203;appender1.xml</p>
     
-      <h3 class="doAnchor" name="usingSSLServerSocketReceiver">Using
+      <h3 class="doAnchor" id="usingSSLServerSocketReceiver">Using
       SSLServerSocketReceiver</h3>
 
       <p>The following configuration repeats the same minimal appender
@@ -341,7 +341,7 @@
       to identify your SSL-enabled logback components</strong>.  See 
       <a href="usingSSL.html">Using SSL</a> for more information.</p>
   
-      <h2 class="doAnchor" name="receiverClientComponents">Receivers
+      <h2 class="doAnchor" id="receiverClientComponents">Receivers
       that Act in the Client Role</h2>
     
       <p>A receiver that is configured to act in the client role initiates
@@ -401,7 +401,7 @@
       </table>
     </div>
 
-      <h3 class="doAnchor" name="usingSocketReceiver">Using
+      <h3 class="doAnchor" id="usingSocketReceiver">Using
       SocketReceiver</h3>
 
       <p>The configuration used for <code>SocketReceiver</code>
@@ -491,7 +491,7 @@
       <p>If you enter a message to send when the receiver is not connected,
       note that the message is simply discarded.</p>
 
-      <h3 class="doAnchor" name="usingSSLSocketReceiver">Using
+      <h3 class="doAnchor" id="usingSSLSocketReceiver">Using
       SocketSSLReceiver</h3>
 
 

--- a/src/site/pages/manual/usingSSL.html
+++ b/src/site/pages/manual/usingSSL.html
@@ -152,7 +152,7 @@
          certificate.
       </p>
       
-      <h4><a name="basicConfig.keyStore"></a>
+      <h4 id="basicConfig.keyStore">
           System Properties for Server Key Store Configuration</h4>
 
           <div class="bodyTable">
@@ -210,7 +210,7 @@
          client component</strong>.
       </p>
         
-      <h4><a name="basicConfig.trustStore"></a>
+      <h4 id="basicConfig.trustStore">
           System Properties for Client Trust Store Configuration</h4>
 
           <div class="bodyTable">
@@ -245,7 +245,7 @@
          that utilizes Logback's SSL-enabled client components.
       </p>         
             
-      <h3 class="doAnchor"><a name="SSLConfiguration"></a>
+      <h3 class="doAnchor" id="SSLConfiguration">
          Advanced SSL Configuration</h3>
       <p>In certain situations, the basic SSL configuration using 
          JSSE system properties is not adequate.  For example, if you
@@ -405,7 +405,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="ssl.keyStore"></a><span class="prop" container="ssl">keyStore</span></td>
+          <td id="ssl.keyStore"><span class="prop" container="ssl">keyStore</span></td>
           <td><a href="../xref/ch/qos/logback/core/net/ssl/KeyStoreFactoryBean.html">
               <code>KeyStoreFactoryBean</code></a>
           </td>
@@ -500,7 +500,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="ssl.trustStore"></a><span class="prop" container="ssl">trustStore</span></td>
+          <td id="ssl.trustStore"><span class="prop" container="ssl">trustStore</span></td>
           <td><a href="../xref/ch/qos/logback/core/net/ssl/KeyStoreFactoryBean.html">
               <code>KeyStoreFactoryBean</code></a>
           </td>
@@ -526,7 +526,7 @@
       </table>
           </div>
 
-      <h4 class="doAnchor"><a name="KeyStoreFactoryBean"></a>
+      <h4 class="doAnchor" id="KeyStoreFactoryBean">
           Key Store Configuration</h4>
           
       <p>The <a href="../xref/ch/qos/logback/core/net/ssl/KeyStoreFactoryBean.html">
@@ -587,7 +587,7 @@
       </table>
           </div>
 
-      <h4><a name="KeyManagerFactoryFactoryBean"></a>
+      <h4 id="KeyManagerFactoryFactoryBean">
           Key Manager Factory Configuration</h4>
           
       <p>The <a href="../xref/ch/qos/logback/core/net/ssl/KeyManagerFactoryFactoryBean.html">
@@ -629,7 +629,7 @@
       </table>
           </div>
 
-      <h4 class="doAnchor"><a name="SecureRandomFactoryBean"></a>
+      <h4 class="doAnchor" id="SecureRandomFactoryBean">
           Secure Random Generator Configuration</h4>
           
       <p>The <a href="../xref/ch/qos/logback/core/net/ssl/SecureRandomFactoryBean.html">
@@ -672,7 +672,7 @@
       </table>
        </div>
 
-      <h4><a name="SSLParametersConfiguration"></a>
+      <h4 id="SSLParametersConfiguration">
           SSL Parameters Configuration</h4>
           
       <p>The <a href="../xref/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.html">
@@ -690,7 +690,7 @@
         </tr>
 
         <tr>
-          <td><a name="parameters.hostnameVerification"></a>
+          <td id="parameters.hostnameVerification">
               <span class="prop" container="parameters">hostnameVerification</span></td>
           <td><code>boolean</code></td>
           <td>
@@ -701,7 +701,7 @@
         </tr>
 
         <tr>
-          <td><a name="parameters.excludedCipherSuites"></a>
+          <td id="parameters.excludedCipherSuites">
               <span class="prop" container="parameters">excludedCipherSuites</span></td>
           <td><code>String</code></td>
           <td>
@@ -721,7 +721,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="parameters.includedCipherSuites"></a>
+          <td id="parameters.includedCipherSuites">
               <span class="prop" container="parameters">includedCipherSuites</span></td>
           <td><code>String</code></td>
           <td>
@@ -742,7 +742,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="parameters.excludedProtocols"></a>
+          <td id="parameters.excludedProtocols">
               <span class="prop" container="parameters">excludedProtocols</span></td>
           <td><code>String</code></td>
           <td>
@@ -762,7 +762,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="parameters.includedProtocols"></a>
+          <td id="parameters.includedProtocols">
               <span class="prop" container="parameters">includedProtocols</span></td>
           <td><code>String</code></td>
           <td>
@@ -783,7 +783,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="parameters.needClientAuth"></a>
+          <td id="parameters.needClientAuth">
               <span class="prop" container="parameters">needClientAuth</span></td>
           <td><code>boolean</code></td>
           <td>Set this property to the value <code>true</code> to 
@@ -793,7 +793,7 @@
           </td>
         </tr>
         <tr>
-          <td><a name="parameters.wantClientAuth"></a>
+          <td id="parameters.wantClientAuth">
               <span class="prop" container="parameters">wantClientAuth</span></td>
           <td><code>boolean</code></td>
           <td>Set this property to the value <code>true</code> to 
@@ -805,7 +805,7 @@
       </table>
           </div>
 
-      <h4><a name="TrustManagerFactoryFactoryBean"></a>
+      <h4 id="TrustManagerFactoryFactoryBean">
           Trust Manager Factory Configuration</h4>
           
       <p>The <a href="../xref/ch/qos/logback/core/net/ssl/TrustManagerFactoryFactoryBean.html">
@@ -847,7 +847,7 @@
       </table>
           </div>
 
-      <h2 class="doAnchor"><a name="Examples"></a>Examples</h2>
+      <h2 class="doAnchor" id="Examples">Examples</h2>
 
       <h3>Using JSSE System Properties</h3>
       <p>JSSE system properties can be used to specify the location and 

--- a/src/site/pages/news.html
+++ b/src/site/pages/news.html
@@ -93,7 +93,7 @@
       </div>
     </div>
 
-    <h3 class="doAnchor" name="1.3.6">2023-03-15 Release of logback versions 1.3.6 and 1.4.6</h3>
+    <h3 class="doAnchor" id="1.3.6">2023-03-15 Release of logback versions 1.3.6 and 1.4.6</h3>
 
     <p class="champion">This release was kindly championed
     by <a href="https://www.lvm.de/privatkunden/">LVM
@@ -132,7 +132,7 @@
     
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.5">2022-11-18 Release of logback versions 1.3.5 and 1.4.5</h3>
+    <h3 class="doAnchor" id="1.3.5">2022-11-18 Release of logback versions 1.3.5 and 1.4.5</h3>
 
     <p>&bull; Fixed incomplete handling of <code>insertFromJNDI</code>
     element in logback-classic configuration files. This
@@ -158,7 +158,7 @@
         
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.4">2022-10-07 Release of logback versions 1.3.4 and 1.4.4</h3>
+    <h3 class="doAnchor" id="1.3.4">2022-10-07 Release of logback versions 1.3.4 and 1.4.4</h3>
 
     <p>&bull; Fixed spurious "transitive" modifier in the requires
     declaration on javax.mail/jakarta.mail in the logback-core
@@ -188,7 +188,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.3">2022-10-02 Release of logback versions 1.3.3 and 1.4.3</h3>
+    <h3 class="doAnchor" id="1.3.3">2022-10-02 Release of logback versions 1.3.3 and 1.4.3</h3>
 
     <p>&bull; Removed spurious <code>System.out.println</code> calls
     in <code>ClassicEnvUtil</code> and <code>ContextInitializer</code>
@@ -203,7 +203,7 @@
 
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.2">2022-10-02 Release of logback versions 1.3.2 and 1.4.2</h3>    
+    <h3 class="doAnchor" id="1.3.2">2022-10-02 Release of logback versions 1.3.2 and 1.4.2</h3>    
 
     
     <p>&bull; Significantly improved the performance of
@@ -264,7 +264,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.1">2022-09-14 Release of logback versions 1.3.1 and 1.4.1</h3>    
+    <h3 class="doAnchor" id="1.3.1">2022-09-14 Release of logback versions 1.3.1 and 1.4.1</h3>    
     
     <p>&bull; Logback-classic now correctly invokes
     <code>DefaultJoranConfigurator</code> when running in a (JPMS)
@@ -294,7 +294,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.0">2022-08-28 Release of logback versions 1.3.0 and 1.4.0</h3>
+    <h3 class="doAnchor" id="1.3.0">2022-08-28 Release of logback versions 1.3.0 and 1.4.0</h3>
     
     <p>Here is a list of changes with respect to the previous
     version.</p>
@@ -375,7 +375,7 @@
     <hr width="80%" align="center" />
 
     
-    <h3 class="doAnchor" name="1.3.0-beta0">2022-08-09 Release of logback version 1.3.0-beta0</h3>
+    <h3 class="doAnchor" id="1.3.0-beta0">2022-08-09 Release of logback version 1.3.0-beta0</h3>
 
     <p>&bull; Escape sequences are no longer interpreted for the
     attribute named <code>value</code> defined in the &lt;variable&gt;
@@ -409,7 +409,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha16">2022-05-19 Release of logback version 1.3.0-alpha16</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha16">2022-05-19 Release of logback version 1.3.0-alpha16</h3>
 
     <p>&bull; Restored <code>SiftingAppender</code> functionality
     which was removed during the rewrite of Joran.</p>
@@ -429,7 +429,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3  class="doAnchor" name="1.3.0-alpha15">2022-05-09 Release of logback version 1.3.0-alpha15</h3>
+    <h3  class="doAnchor" id="1.3.0-alpha15">2022-05-09 Release of logback version 1.3.0-alpha15</h3>
 
     <p class="champion">This release is championed by <a
     href="https://commercetools.com/">commercetools</a>, a leader
@@ -465,7 +465,7 @@
     
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="logback.db.1.2.11.1">2022-04-20 Release of <b>logback.db</b> version 1.2.11.1</h3>
+    <h3 class="doAnchor" id="logback.db.1.2.11.1">2022-04-20 Release of <b>logback.db</b> version 1.2.11.1</h3>
 
     <p>As of logback version 1.2.8 <code>DBAppender</code> no longer
       ships with logback. However, 
@@ -490,7 +490,7 @@
         
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="logback.db.1.2.11">2022-04-15 Release of <b>logback.db</b> version 1.2.11</h3>
+    <h3 class="doAnchor" id="logback.db.1.2.11">2022-04-15 Release of <b>logback.db</b> version 1.2.11</h3>
 
     <p>As of logback version 1.2.8 <code>DBAppender</code> no longer
     ships with logback. However, the logback-db project remedies this
@@ -499,7 +499,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3  class="doAnchor" name="1.2.11">2022-03-05 Release of version 1.2.11</h3>
+    <h3  class="doAnchor" id="1.2.11">2022-03-05 Release of version 1.2.11</h3>
 
     <p>&bull;&nbsp; Backported fix for <a
     href="https://jira.qos.ch/browse/LOGBACK-1027">LOGBACK-1027</a>.
@@ -517,7 +517,7 @@
 
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha14">2021-02-11 Release of version 1.3.0-alpha14</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha14">2021-02-11 Release of version 1.3.0-alpha14</h3>
 
 
     <p>&bull;&nbsp; A bug was introduced in 1.3.0-alpha13 which caused
@@ -531,7 +531,7 @@
     
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.0-alpha13">2021-01-31 Release of version 1.3.0-alpha13</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha13">2021-01-31 Release of version 1.3.0-alpha13</h3>
 
     <p>&bull;&nbsp; Starting with version 1.3.0-alpha13 logback
     releases are reproducible. This means that anyone checking out the
@@ -563,7 +563,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.2.10">2021-12-23 Release of version 1.2.10</h3>
+    <h3 class="doAnchor" id="1.2.10">2021-12-23 Release of version 1.2.10</h3>
 
     <p>&bull;&nbsp; <code>ContextInitializer</code> no longer
     complains about missing <em>logback.groovy</em> configuration
@@ -573,7 +573,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.0-alpha12">2021-12-22 Release of version 1.3.0-alpha12</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha12">2021-12-22 Release of version 1.3.0-alpha12</h3>
 
     <p><b>Note that 1.3.0-alpha12 contains the same security related
     changes as version 1.3.0-alpha11 and 1.2.9.</b></p>
@@ -608,7 +608,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.9">2021-12-16 Release of version 1.2.9</h3>
+    <h3 class="doAnchor" id="1.2.9">2021-12-16 Release of version 1.2.9</h3>
 
     
     <p class="highlight">We note that the vulnerability mentioned in
@@ -660,7 +660,7 @@
 
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.0-alpha11">202-12-16 Release of version 1.3.0-alpha11</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha11">202-12-16 Release of version 1.3.0-alpha11</h3>
 
     <p>Note that 1.3.0-alpha11 contains the same security related
     changes as version 1.2.9.</p>    
@@ -685,7 +685,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.8">2021-12-14 Release of version 1.2.8</h3>
+    <h3 class="doAnchor" id="1.2.8">2021-12-14 Release of version 1.2.8</h3>
     
     <p>&bull; In response to <a
     href="https://cve.report/CVE-2021-42550">CVE-2021-42550</a> and <a
@@ -704,7 +704,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.7">2021-11-11 - Release of version 1.2.7</h3>
+    <h3 class="doAnchor" id="1.2.7">2021-11-11 - Release of version 1.2.7</h3>
 
     <p>&bull; Added <a
     href="manual/usingSSL.html#parametersHostnameVerification">hostnameVerification</a>
@@ -717,7 +717,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.6">2021-09-10 Release of version 1.2.6</h3>
+    <h3 class="doAnchor" id="1.2.6">2021-09-10 Release of version 1.2.6</h3>
 
     <p>&bull; To prevent XML eXternal Entity injection (XXE) attacks, Joran
     no longer reads external entities passed in XML files. This fixes
@@ -728,7 +728,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha10">2021-08-23 Release of version 1.3.0-alpha10</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha10">2021-08-23 Release of version 1.3.0-alpha10</h3>
 
     <p>&bull; <code>CachingDateFormatter</code> is now
     synchronization-free and performs about 30 times faster. This fixes
@@ -773,7 +773,7 @@
 
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha9">2021-08-13 Release of version 1.3.0-alpha9</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha9">2021-08-13 Release of version 1.3.0-alpha9</h3>
 
     <p>&bull; In <code>ILoggingEvent</code>, added a <code>getMarker()</code>
     method with a default implementation returning the first marker in
@@ -786,7 +786,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha8">2021-08-12 Release of version 1.3.0-alpha8</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha8">2021-08-12 Release of version 1.3.0-alpha8</h3>
 
     <p>&bull; Upped the requested slf4j-api version by
     <code>LogbackServiceProvider</code> to 2.0.99 instead of
@@ -795,7 +795,7 @@
     
     <hr width="80%" align="center" />
     
-    <h3 class="doAnchor" name="1.3.0-alpha7">2021-08-10 Release of version 1.3.0-alpha7</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha7">2021-08-10 Release of version 1.3.0-alpha7</h3>
 
     <p>&bull; <code>AccessEvent</code> in the logback-access module now tries
     to get a reference to a given <code>HttpRequest</code> session
@@ -845,7 +845,7 @@
     reported by Michael Skells who also provided a relevant PR.
     </p>
     
-    <h3 class="doAnchor" name="1.3.0-alpha6">2021-07-28 Release of version 1.3.0-alpha6</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha6">2021-07-28 Release of version 1.3.0-alpha6</h3>
 
     <p>Joran, logback's configuration system, has been rewritten to
     use an internal representation model which can be processed
@@ -865,7 +865,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.5">2021-07-26 Release of version 1.2.5</h3>
+    <h3 class="doAnchor" id="1.2.5">2021-07-26 Release of version 1.2.5</h3>
 
     <p>Instead of an <code>Appender</code>, the
     <code>LayoutWrappingEncoder</code> now accepts a variable of type
@@ -876,7 +876,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.4">2021-07-19 Release of version 1.2.4</h3>
+    <h3 class="doAnchor" id="1.2.4">2021-07-19 Release of version 1.2.4</h3>
     
     <p>Added support for minimum length in %i filename pattern. This
     fixes <a
@@ -899,7 +899,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha5">2019-10-11 Release of version 1.3.0-alpha5</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha5">2019-10-11 Release of version 1.3.0-alpha5</h3>
     
     <p>ConsoleAppender now delegates filtering of ANSI sequences to
     Jansi. This fixes <a
@@ -909,7 +909,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha4">2018-02-11 Release of version 1.3.0-alpha4</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha4">2018-02-11 Release of version 1.3.0-alpha4</h3>
 
     <div class="breaking">
 
@@ -940,7 +940,7 @@
 
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha3">February 10th, 2018, Release of version 1.3.0-alpha3</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha3">February 10th, 2018, Release of version 1.3.0-alpha3</h3>
 
     <p>Under JPMS (Java 9), allow user code to implement
     <code>ch.qos.logback.classic.&#8203;spi.Configurator</code> as a
@@ -957,14 +957,14 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha2">2018-01-30 Release of version 1.3.0-alpha2</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha2">2018-01-30 Release of version 1.3.0-alpha2</h3>
 
     <p>Depend on SLF4J version 1.8.0-beta1 instead of
     1.8.0-beta1-SNAPSHOT.</p>
 
     <p>Fix build under Travis.</p>
     
-    <h3 class="doAnchor" name="1.3.0-alpha1">2018-01-30 Release of version 1.3.0-alpha1</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha1">2018-01-30 Release of version 1.3.0-alpha1</h3>
        
     <p>In the absence of a <span class="attr">class</span> attribute,
     the <code>shutdownHook</code> configuration directive now
@@ -1029,7 +1029,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.3.0-alpha0">2018-01-18 Release of version 1.3.0-alpha0</h3>
+    <h3 class="doAnchor" id="1.3.0-alpha0">2018-01-18 Release of version 1.3.0-alpha0</h3>
     
    
     <p>Added support for minimum length in %i filename pattern. This
@@ -1050,7 +1050,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.3">2017-03-30 Release of version 1.2.3</h3>
+    <h3 class="doAnchor" id="1.2.3">2017-03-30 Release of version 1.2.3</h3>
 
     <p>Fix unintentional dependency on
     <code>OutputStreamAppender</code> in
@@ -1068,7 +1068,7 @@
     href="https://jira.qos.ch/browse/LOGBACK-1282">LOGBACK-1282</a> by
     Clas Forsberg.</p>
     
-    <h3 class="doAnchor" name="1.2.2">2017-03-16 Release of version 1.2.2</h3>
+    <h3 class="doAnchor" id="1.2.2">2017-03-16 Release of version 1.2.2</h3>
 
     <p><code>AsyncAppender</code> no longer drops events when the
     current thread has its interrupt flag set. This issue was reported
@@ -1094,7 +1094,7 @@
     
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.1.11">March 1st, 2017, Release of version 1.1.11</h3>
+    <h3 class="doAnchor" id="1.1.11">March 1st, 2017, Release of version 1.1.11</h3>
     
     <p>Fix thread-safety issue with <code>PatternLayoutBase</code>
     reported in <a
@@ -1104,7 +1104,7 @@
 
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.1">February 9th, 2017, Release of version 1.2.1</h3>
+    <h3 class="doAnchor" id="1.2.1">February 9th, 2017, Release of version 1.2.1</h3>
 
     <p>To ensure backward compatibility of configuration files, the
     <span class="prop">immediateFlush</span> property set for a
@@ -1114,7 +1114,7 @@
 
     <hr width="80%" align="center" />
 
-    <h3 class="doAnchor" name="1.2.0">2017-02-08 Release of version 1.2.0</h3>
+    <h3 class="doAnchor" id="1.2.0">2017-02-08 Release of version 1.2.0</h3>
 
     <div class="breaking">
       <h4><code>Encoder</code> interface has changed and is no longer

--- a/src/site/pages/reasonsToSwitch.html
+++ b/src/site/pages/reasonsToSwitch.html
@@ -33,14 +33,14 @@
     </p>
 
 
-    <h3 class="doAnchor" name="fasterImpl">Faster implementation</h3>
+    <h3 class="doAnchor" id="fasterImpl">Faster implementation</h3>
 
     <p>Based on our previous work on log4j 1.x, logback internals have
         been re-written to perform about ten times faster on certain
         critical execution paths. Not only are logback components faster,
         they have a smaller memory footprint as well.</p>
 
-    <h3 class="doAnchor" name="tdd">Extensive battery of tests</h3>
+    <h3 class="doAnchor" id="tdd">Extensive battery of tests</h3>
 
     <p>Logback comes with a very extensive battery of tests developed
         over the course of several years and untold hours of work. While
@@ -51,7 +51,7 @@
         conditions.
     </p>
 
-    <h3 class="doAnchor" name="slf4j">logback-classic speaks SLF4J
+    <h3 class="doAnchor" id="slf4j">logback-classic speaks SLF4J
         natively</h3>
 
     <p>Since the <code>Logger</code> class in logback-classic
@@ -65,12 +65,12 @@
         in switching logging frameworks.
     </p>
 
-    <h3 class="doAnchor" name="docs">Extensive documentation</h3>
+    <h3 class="doAnchor" id="docs">Extensive documentation</h3>
 
     <p>Logback ships with detailed and constantly updated
         documentation.</p>
 
-    <h3 class="doAnchor" name="autoScan">Automatic reloading of
+    <h3 class="doAnchor" id="autoScan">Automatic reloading of
         configuration files</h3>
 
     <p>Logback-classic can <a
@@ -83,7 +83,7 @@
         of a separate thread for scanning.
     </p>
 
-    <h3 class="doAnchor" name="grace">Graceful recovery from I/O
+    <h3 class="doAnchor" id="grace">Graceful recovery from I/O
         failures</h3>
 
     <p>Logback's <code>FileAppender</code> and all its subclasses,
@@ -95,7 +95,7 @@
         from the previous error condition.
     </p>
 
-    <h3 class="doAnchor" name="maxHistory">Automatic removal of old
+    <h3 class="doAnchor" id="maxHistory">Automatic removal of old
         log archives</h3>
 
     <p>By setting the <span class="option">maxHistory</span> property
@@ -110,7 +110,7 @@
         files older than 12 months will be automatically removed.
     </p>
 
-    <h3 class="doAnchor" name="compression">Automatic compression of
+    <h3 class="doAnchor" id="compression">Automatic compression of
         archived log files</h3>
 
     <p><a
@@ -121,7 +121,7 @@
         duration of the compression.
     </p>
 
-    <h3 class="doAnchor" name="prudent">Prudent mode</h3>
+    <h3 class="doAnchor" id="prudent">Prudent mode</h3>
 
     <p>In <a href="manual/appenders.html#prudent">prudent mode</a>,
         multiple <code>FileAppender</code> instances running on multiple
@@ -131,7 +131,7 @@
     </p>
 
 
-    <h3 class="doAnchor" name="conditional">Conditional processing of
+    <h3 class="doAnchor" id="conditional">Conditional processing of
         configuration files</h3>
 
     <p>Developers often need to juggle between several logback
@@ -147,7 +147,7 @@
     </p>
 
 
-    <h3 class="doAnchor" name="filters">Filters</h3>
+    <h3 class="doAnchor" id="filters">Filters</h3>
 
     <p>Logback comes with a wide array of <a
             href="manual/filters.html">filtering capabilities</a> going much
@@ -180,7 +180,7 @@
     </p>
 
 
-    <h3 class="doAnchor" name="sift">SiftingAppender</h3>
+    <h3 class="doAnchor" id="sift">SiftingAppender</h3>
 
     <p><a
             href="manual/appenders.html#SiftingAppender">SiftingAppender</a>
@@ -191,7 +191,7 @@
         user go into distinct log files, one log file per user.
     </p>
 
-    <h3 class="doAnchor" name="packagingData">Stack traces with
+    <h3 class="doAnchor" id="packagingData">Stack traces with
         packaging data</h3>
 
     <p>When logback prints an exception, the stack trace will include
@@ -230,7 +230,7 @@ java.lang.Exception: 99 is invalid
             their IDE</a>.
     </p>
 
-    <h3 class="doAnchor" name="logbackAccess">Logback-access,
+    <h3 class="doAnchor" id="logbackAccess">Logback-access,
         i.e. HTTP-access logging with brains, is an integral part of
         logback</h3>
 
@@ -241,7 +241,7 @@ java.lang.Exception: 99 is invalid
         design, all the logback-classic features you love are
         available in logback-access as well.</p>
 
-    <h3 class="doAnchor" name="inSummary">In summary</h3>
+    <h3 class="doAnchor" id="inSummary">In summary</h3>
 
     <p>We have listed a number of reasons for preferring logback over
         log4j 1.x. Given that logback builds upon on our previous work on

--- a/src/site/pages/recipes/captureHttp.html
+++ b/src/site/pages/recipes/captureHttp.html
@@ -68,7 +68,7 @@
 
       </p>
 
-      <h3 class="doAnchor" name="capturing">Capturing</h3>
+      <h3 class="doAnchor" id="capturing">Capturing</h3>
 
       <p>The <code>TeeFilter</code>, as any other servlet filter,
       needs to be declared in your web-application's <em>web.xml</em>
@@ -152,7 +152,7 @@ Set-Cookie: JSESSIONID=bgebt99ce9om;path=/logback-demo
 
 <p>&nbsp;</p>
 
-      <h3 class="doAnchor" name="disabling">Disabling <code>TeeFilter</code> in the production environment</h3>
+      <h3 class="doAnchor" id="disabling">Disabling <code>TeeFilter</code> in the production environment</h3>
 
       <p>Due to its intrusive nature, <code>TeeFilter</code> can slow
       down performance. Moreover, although we have fixed all currently
@@ -188,7 +188,7 @@ Set-Cookie: JSESSIONID=bgebt99ce9om;path=/logback-demo
       list.
       </p>
 
-      <h3 class="doAnchor" name="filtering">Filtering captured
+      <h3 class="doAnchor" id="filtering">Filtering captured
       requests</h3>
 
       <p>Let assume that our web-application is deployed in a

--- a/src/site/pages/setup.html
+++ b/src/site/pages/setup.html
@@ -47,7 +47,7 @@
     </p>
     
 
-    <h3 class="doAnchor" name="commandLine">Running from the command
+    <h3 class="doAnchor" id="commandLine">Running from the command
     line</h3>
     
     <p>You can launch the first sample application,
@@ -83,7 +83,7 @@
    </p>
 
     
-   <h2 class="doAnchor" name="mavenBuild">Maven dependency
+   <h2 class="doAnchor" id="mavenBuild">Maven dependency
     declaration</h2>
 
     <p>To use logback-classic in your Maven project, declare the
@@ -111,9 +111,9 @@
   &lt;version>${project.version}&lt;/version>
 &lt;/dependency></pre>
 
-   <h2 class="doAnchor" name="optionalDeps">Optional dependencies</h2>
+   <h2 class="doAnchor" id="optionalDeps">Optional dependencies</h2>
 
-   <h3 class="doAnchor" name="SMTP"><code>SMTPAppender</code> requires
+   <h3 class="doAnchor" id="SMTP"><code>SMTPAppender</code> requires
    JavaMail API</h3>
 
    <p><code>SMTPAppender</code> related examples require the JavaMail
@@ -136,7 +136,7 @@
 &lt;/dependency></pre>
 
 
-   <h3 class="doAnchor" name="janino">Conditional processing and
+   <h3 class="doAnchor" id="janino">Conditional processing and
    <code>JaninoEventEvaluator</code> require the Janino library</h3>
    
    <p><a href="manual/configuration.html#conditional">Conditional
@@ -165,7 +165,7 @@
 &lt;/dependency></pre>
 
 
-   <h2 class="doAnchor" name="ide">Building Logback with an IDE</h2>
+   <h2 class="doAnchor" id="ide">Building Logback with an IDE</h2>
 
    <p class="big green">As of version 1.3.x, logback requires Java 9
    to build. However, it can be run on Java 8 or later. Logback
@@ -182,7 +182,7 @@
    instructions below, if you have trouble building logback from the
    sources, just ask for help on the logback-dev mailing list.</p>
 
-   <h3 class="doAnchor" name="idea">Building logback with IntelliJ
+   <h3 class="doAnchor" id="idea">Building logback with IntelliJ
    IDEA</h3>
 
    <p>Assuming you have the latest version of IntelliJ IDEA installed,


### PR DESCRIPTION
Also make anchors work without JavaScript. This also allows to directly link to specific parts of a page.