### PR TITLE
Fix typo in spelling of relatively

### DIFF
--- a/src/site/pages/manual/appenders.html
+++ b/src/site/pages/manual/appenders.html
@@ -1353,7 +1353,7 @@ public interface RollingPolicy extends LifeCycle {
     <code>TimeBasedRollingPolicy</code> described above and setting
     the <a href="#tbrpTotalSizeCap"><span
     class="option">totalSizeCap</span></a> property should be amply
-    sufficient. Moreover, given that file renaming is a releatively
+    sufficient. Moreover, given that file renaming is a relatively
     slow process and is frought with problems, we discourage the use
     of <code>SizeAndTimeBasedRollingPolicy</code> unless you have a
     real-world use case.</p>
@@ -1486,7 +1486,7 @@ public interface RollingPolicy extends LifeCycle {
    <h4 class="doAnchor" name="FixedWindowRollingPolicy">FixedWindowRollingPolicy</h4>
 
    
-   <p><b>Given that file renaming is a releatively slow process and is
+   <p><b>Given that file renaming is a relatively slow process and is
    frought with problems, we consider
    <code>FixedWindowRollingPolicy</code> as a deprecated policy and do
    not recommend its use</b>.</p>


### PR DESCRIPTION
Fixed two typos. "releatively" should be "relatively"