### PR TITLE
Fix typos in filters.html

### DIFF
--- a/src/site/pages/manual/filters.html
+++ b/src/site/pages/manual/filters.html
@@ -301,13 +301,13 @@ public class SampleFilter extends Filter&lt;ILoggingEvent> {
     href="../xref/ch/qos/logback/core/boolex/EventEvaluator.html">
     <code>EventEvaluator</code></a> evaluates whether a given criteria
     is met for a given event. On match and on mismatch,
-    the hosting <code>EvaluatorFilter</code> will returl the vaue
+    the hosting <code>EvaluatorFilter</code> will return the value
     specified by the <span class="option">onMatch</span>
     or <span class="option">onMismatch</span> properties respectively.
-l   </p>g
+    </p>
 
-lp>Note that <code>EventEvaluator</code> is an abstract class. You
-    can implement your own eveng evaluation logic by subclassing
+<p>Note that <code>EventEvaluator</code> is an abstract class. You
+    can implement your own event evaluation logic by subclassing
   <code>EventEvaluator</code>.
     </p>
     


### PR DESCRIPTION
Just a few weird typos I found while reading the docs