### PR TITLE
doc(pages.manual.layouts): fix wrong method referred

### DIFF
--- a/src/site/pages/manual/layouts.html
+++ b/src/site/pages/manual/layouts.html
@@ -39,7 +39,7 @@
         <p>In case you were wondering, layouts have nothing to do with
 		large estates in Florida.  Layouts are logback components
 		responsible for transforming an incoming event into a String.  The
-		<code>format()</code> method in the <a
+		<code>doLayout()</code> method in the <a
 		href="../xref/ch/qos/logback/core/Layout.html"><code>Layout</code></a>
 		interface takes an object that represents an event (of any type)
 		and returns a String. A synopsis of the <code>Layout</code>


### PR DESCRIPTION
## Description
* Fix wrong method referred in "manual.layouts"

## How to review?
* Go to [Layout.java](https://github.com/qos-ch/logback/blob/master/logback-core/src/main/java/ch/qos/logback/core/Layout.java)
* Check that 
  * `format()` does NOT exist
  * `String doLayout(E event);` is the only method which matches with the description, found in https://logback.qos.ch/manual/layouts.html for

> ... takes an object that represents an event (of any type) and returns a String ..

