### PR TITLE
Fix typo in configuration.html

### DIFF
--- a/src/site/pages/manual/configuration.html
+++ b/src/site/pages/manual/configuration.html
@@ -462,7 +462,7 @@ public static void main(String[] args) {
 
    <p>Enabling output of status data usually goes a
    long way in the diagnosis of issues with logback. Note that errors
-   can also occur post-configuration, e.g. when a disk a full or log
+   can also occur post-configuration, e.g. when a disk is full or log
    files cannot be archived due to permission errors. As such, it is
    highly recommended that you register a <code>StatusListener</code>
    as discussed below.</p>


### PR DESCRIPTION
This PR fixes a typo in the `configuration.html` file.