### PR TITLE
Fix typo in bufferSize documentation

### DIFF
--- a/src/site/pages/manual/appenders.html
+++ b/src/site/pages/manual/appenders.html
@@ -485,13 +485,13 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
        size of the output buffer in case <span
        class="prop">immediateFlush</span> option is set to
        false. Default value for <span class="prop">bufferSize</span>
-       is 8192. The value 256KKB seems to sufficient even in cases of
+       is 8192. The value 256 KB seems to sufficient even in cases of
        very heavy and persistent loads.</p>
 
        <p>Options in defined in units of "FileSize" can be specified
        in bytes, kilobytes, megabytes or gigabytes by suffixing a
        numeric value with KB, MB and respectively GB. For example,
-       5000000, 5000KB, 5MB and 2GB are all valid values, with the
+       5242880, 5120KB, 5MB and 2GB are all valid values, with the
        first three being equivalent.
        </p>
        </td>


### PR DESCRIPTION
Fixing typo in buffersSize documentation. The coefficient for KB and MB is 1024, so example data adjusted accordingly.