### PR TITLE
Fix Configuration errors

### DIFF
--- a/src/site/pages/manual/configuration.html
+++ b/src/site/pages/manual/configuration.html
@@ -2470,9 +2470,9 @@ fileName=myApp.log
 
 
   <p><code>ProppertyConditionBase</code> class defines the following
-  helper methods <code>property(String key)</code>, <code>p(String
-  key)</code>, <code>isDefined(String key)</code>,
-  <code>isDefined(String key)</code>, <code>isNull(String key)</code>.
+  helper methods: <code>property(String key)</code>, <code>p(String
+  key)</code>, <code>isDefined(String key)</code>, and
+  <code>isNull(String key)</code>.
 
   <p>For a key passed as argument, the <code>property(String
   key)</code> or its shorter equivalent <code>p(String key)</code>


### PR DESCRIPTION
Add a missing colon character, add a missing "and", and remove a duplicate "isDefined(String key)" method (i.e., it was listed twice).